### PR TITLE
Slack notifications and GitHub deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The overall structure of this repository can be broken down as follows:
   - The CDH Ansible vault key. This can be referenced on the command line or
   better set as in the Bash session, i.e.
   `export ANSIBLE_VAULT_PASSWORD_FILE=/path/to/.passwd`
+  - A GitHub [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
+  for any playbook that uses the `create_deployment` and `close_deployment` roles.
+  You can set this in your Bash session as `ANSIBLE_GITHUB_TOKEN` or pass it
+  on the command line as `-e github_token=`
   - The CDH deploy bot key. This can be added to ssh-agent or in `~/.ssh/config`.
   All production deploys must be on the campus network (including VPN) and
   proxy through the QA server to production, with an ssh config stanza

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -1,4 +1,8 @@
 ---
+
+# GitHub token
+github_token: '{{ lookup("env", "ANSIBLE_GITHUB_TOKEN") | default("") }}'
+
 # email_host_password
 email_host_password: '{{ vault_email_host_password }}'
 

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -1,7 +1,11 @@
 ---
 
-# GitHub token
+# GitHub settings
 github_token: '{{ lookup("env", "ANSIBLE_GITHUB_TOKEN") | default("") }}'
+api_base: https://api.github.com
+deployments_endpoint: '{{api_base}}/repos/{{ repo }}/deployments'
+deploy_environment: '{{ staging|default(None) or qa|default(None) or production }}'
+deploy_description: 'Deploying {{ gitref }} to {{ deploy_environment }}'
 
 # email_host_password
 email_host_password: '{{ vault_email_host_password }}'

--- a/group_vars/staging/vars.yml
+++ b/group_vars/staging/vars.yml
@@ -23,3 +23,4 @@ solr_admin_url: '{{ solr_url }}admin/cores'
 # chooses a random number from 0 to 99999, adds a random salt, and hashes using
 # sha256.
 secret_key: '{{ 99999 |random|string|password_hash("sha256") }}'
+staging: staging

--- a/mep_qa.yml
+++ b/mep_qa.yml
@@ -19,3 +19,4 @@
     - django_migrate
     - finalize_deploy
     - restart_httpd
+    - close_deployment

--- a/mep_qa.yml
+++ b/mep_qa.yml
@@ -7,6 +7,7 @@
     LD_LIBRARY_PATH: '{{ ld_library_path }}'
     PYTHONPATH: '{{ python_path }}'
   roles:
+    - create_deployment
     - build_project_repo
     - build_virtualenv
     - configure_logging

--- a/ppa_qa.yml
+++ b/ppa_qa.yml
@@ -20,4 +20,4 @@
     - django_migrate
     - finalize_deploy
     - restart_httpd
-    
+    - close_deployment

--- a/ppa_qa.yml
+++ b/ppa_qa.yml
@@ -7,6 +7,7 @@
     LD_LIBRARY_PATH: '{{ ld_library_path }}'
     PYTHONPATH: '{{ python_path }}'
   roles:
+    - create_deployment
     - build_project_repo
     - build_virtualenv
     - configure_logging
@@ -19,3 +20,4 @@
     - django_migrate
     - finalize_deploy
     - restart_httpd
+    

--- a/ppa_staging.yml
+++ b/ppa_staging.yml
@@ -7,6 +7,7 @@
     LD_LIBRARY_PATH: '{{ ld_library_path }}'
     PYTHONPATH: '{{ python_path }}'
   roles:
+    - create_deployment
     - { role: prep_staging, become: true }
     - build_project_repo
     - build_virtualenv

--- a/roles/backup_database/tasks/main.yml
+++ b/roles/backup_database/tasks/main.yml
@@ -5,7 +5,11 @@
 # The host delegation causes it to run not on the production VM, but the
 # centralized DB server. All variables are set at the group_vars level.
 ###
-- name: Backup DB for snap restore
-  shell: 'mysqldump --opt {{ db_name }} > {{ db_backup }}'
-  args:
-    executable: /bin/bash
+- name: Database backup
+  block:
+    - name: Backup DB for snap restore
+      shell: 'mysqldump --opt {{ db_name }} > {{ db_backup }}'
+      args:
+        executable: /bin/bash
+  rescue:
+    - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/build_npm/tasks/main.yml
+++ b/roles/build_npm/tasks/main.yml
@@ -7,6 +7,10 @@
 #
 ###
 ---
-- name: Do npm install for dependencies
-  npm:
-    path: '{{ deploy }}'
+- name: npm configuration tasks
+  block:
+    - name: Do npm install for dependencies
+      npm:
+        path: '{{ deploy }}'
+  rescue:
+    - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/build_project_repo/tasks/main.yml
+++ b/roles/build_project_repo/tasks/main.yml
@@ -7,34 +7,38 @@
 # directory.
 #
 ###
-- name: Debug environmental variables early in deploy cycle
-  debug:
-    msg: 'PATH: {{ path }} / LD_LIBRARY_PATH: {{ ld_library_path }} / PYTHONPATH: {{ python_path}}'
-    verbosity: 2
-- name: Clone project repository and set to the correct version
-  git:
-    repo: '{{ repo_url }}/'
-    dest: '{{ clone_root }}/{{ repo }}'
-    version: '{{ gitref }}'
-  # register repo_info for group_vars
-  register: repo_info
-- name: Get version information from __init__.py for Django projects
-  # This script is present in get_ver.py, and should be safe for all
-  # system pythons greater than 2.
-  script: get_ver.py {{ clone_root}}/{{ repo }} {{ django_app }}
-  register: ver
-  check_mode: no
-  tags:
-    - django
-- name: Create the deploy directory (to recursively create parent dirs if necessary)
-  file:
-    state: directory
-    dest: '{{ deploy }}'
-- name: Sync checkout to deploy directory
-  synchronize:
-    src: '{{ clone_root }}/{{ repo }}/'
-    # deploy constructed dynamicallly in group_vars
-    dest: '{{ deploy }}/'
-  # sync remotely -- inventory_hostname is a magic var that always points
-  # to host where the playbook is being run.
-  delegate_to: '{{ inventory_hostname }}'
+- name: Clone and deploy a project repository
+  block:
+    - name: Debug environmental variables early in deploy cycle
+      debug:
+        msg: 'PATH: {{ path }} / LD_LIBRARY_PATH: {{ ld_library_path }} / PYTHONPATH: {{ python_path}}'
+        verbosity: 2
+    - name: Clone project repository and set to the correct version
+      git:
+        repo: '{{ repo_url }}/'
+        dest: '{{ clone_root }}/{{ repo }}'
+        version: '{{ gitref }}'
+      # register repo_info for group_vars
+      register: repo_info
+    - name: Get version information from __init__.py for Django projects
+      # This script is present in get_ver.py, and should be safe for all
+      # system pythons greater than 2.
+      script: get_ver.py {{ clone_root}}/{{ repo }} {{ django_app }}
+      register: ver
+      check_mode: no
+      tags:
+        - django
+    - name: Create the deploy directory (to recursively create parent dirs if necessary)
+      file:
+        state: directory
+        dest: '{{ deploy }}'
+    - name: Sync checkout to deploy directory
+      synchronize:
+        src: '{{ clone_root }}/{{ repo }}/'
+        # deploy constructed dynamicallly in group_vars
+        dest: '{{ deploy }}/'
+      # sync remotely -- inventory_hostname is a magic var that always points
+      # to host where the playbook is being run.
+      delegate_to: '{{ inventory_hostname }}'
+  rescue:
+    - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/build_virtualenv/tasks/main.yml
+++ b/roles/build_virtualenv/tasks/main.yml
@@ -3,36 +3,40 @@
 # from requirements.txt.
 #
 ##
-- name: Upgrade pip to latest in virtualenv
-  pip:
-    name: pip
-    state: latest
-    virtualenv: "{{ deploy }}/env"
-    virtualenv_site_packages: yes
-- name: Set perms
-  file:
-      path: "{{ deploy }}/env"
-      state: directory
-      mode: "u+rwx,g+rwx,o-rw"
-# The following two stanzas only run when override variables are defined
-# and allow the user to dynamically update requirements files if necessary.      
-- name: Update requirements based on a supplied template
-  template:
-    src: '{{ new_requirements }}'
-    dest: '{{ deploy }}/requirements.{{ requirements_type }}'
-  when:
-    new_requirements is defined
-- name: Update requirements dynamically using extravars
-  lineinfile:
-    regexp: '^{{ item | regex_replace("[<=>]{1,2}.*$") }}'
-    line: '{{ item }}'
-    path: '{{ deploy }}/requirements.{{ requirements_type }}'
-  when:
-    pip_updates is defined
-  with_items:
-    '{{ pip_updates }}'
-- name: Install requirements via pip (MySQLdb should be system version and skipped)
-  pip:
-    virtualenv: "{{ deploy }}/env"
-    requirements: "{{ deploy }}/requirements.{{ requirements_type }}"
-    virtualenv_site_packages: yes
+- name: Create and build python virtual environment
+  block:
+    - name: Upgrade pip to latest in virtualenv
+      pip:
+        name: pip
+        state: latest
+        virtualenv: "{{ deploy }}/env"
+        virtualenv_site_packages: yes
+    - name: Set perms
+      file:
+          path: "{{ deploy }}/env"
+          state: directory
+          mode: "u+rwx,g+rwx,o-rw"
+    # The following two stanzas only run when override variables are defined
+    # and allow the user to dynamically update requirements files if necessary.
+    - name: Update requirements based on a supplied template
+      template:
+        src: '{{ new_requirements }}'
+        dest: '{{ deploy }}/requirements.{{ requirements_type }}'
+      when:
+        new_requirements is defined
+    - name: Update requirements dynamically using extravars
+      lineinfile:
+        regexp: '^{{ item | regex_replace("[<=>]{1,2}.*$") }}'
+        line: '{{ item }}'
+        path: '{{ deploy }}/requirements.{{ requirements_type }}'
+      when:
+        pip_updates is defined
+      with_items:
+        '{{ pip_updates }}'
+    - name: Install requirements via pip (MySQLdb should be system version and skipped)
+      pip:
+        virtualenv: "{{ deploy }}/env"
+        requirements: "{{ deploy }}/requirements.{{ requirements_type }}"
+        virtualenv_site_packages: yes
+  rescue:
+    - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/close_deployment/tasks/complete_deploy.yml
+++ b/roles/close_deployment/tasks/complete_deploy.yml
@@ -1,0 +1,17 @@
+###
+# Closes a successful GitHub deployment, depends on deployment variable
+# registered by create_deployment task
+###
+- block:
+  - name: Close GitHub deployment as a success.
+    uri:
+      url: '{{ deployment.json.url }}/statuses'
+      body_format: json
+      method: POST
+      status_code: 201
+      body:
+          state: "success"
+          description: "Deployment succeeded"
+      headers:
+          Authorization: "token {{ github_token }}"
+    # no rescue because if this fails, closing an errored deploy will too!

--- a/roles/configure_logging/tasks/main.yml
+++ b/roles/configure_logging/tasks/main.yml
@@ -2,22 +2,25 @@
 # This Ansible task creates a logging file with appropriate permissions for
 # Apache to write log files for the Django application.
 ###
----
-- name: Create logging directory
-  file:
-    path: '{{ logging_dir }}'
-    state: directory
-    mode: 0770
-- name: For QA, set logging directory group to the Django project group
-  file:
-    path: '{{ logging_dir }}'
-    group: '{{ project_user }}'
-    recurse: true
-  when: qa is defined
-- name: Create logging directory default acl & set sticky bit
-  shell: 'chmod g+s {{ logging_dir }} && setfacl -d -m g::rw {{ logging_dir }}'
-  args:
-    warn: false
-  # using a command because the individual module's functionality (esp acl and file)
-  # are misbehaving when used in concert
-  # The sticky bit is really only needed in qa, but is nice insurance on prod
+- name: Set up and configure logging
+  block:
+    - name: Create logging directory
+      file:
+        path: '{{ logging_dir }}'
+        state: directory
+        mode: 0770
+    - name: For QA, set logging directory group to the Django project group
+      file:
+        path: '{{ logging_dir }}'
+        group: '{{ project_user }}'
+        recurse: true
+      when: qa is defined
+    - name: Create logging directory default acl & set sticky bit
+      shell: 'chmod g+s {{ logging_dir }} && setfacl -d -m g::rw {{ logging_dir }}'
+      args:
+        warn: false
+      # using a command because the individual module's functionality (esp acl and file)
+      # are misbehaving when used in concert
+      # The sticky bit is really only needed in qa, but is nice insurance on prod
+  rescue:
+    - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/configure_media/tasks/main.yml
+++ b/roles/configure_media/tasks/main.yml
@@ -1,40 +1,43 @@
 ###
 #  Configure MEDIA_ROOT and folders for a Django deploy
 ###
----
-- name: Create media root if it does not already exist
-  file:
-      path: '{{ media_root }}'
-      state: directory
-      mode: "u=rwX,g=rwX,o=X"
-      recurse: yes
-- name: If on qa, set folder to the appropriate project user instead
-  file:
-      path: '{{ media_root }}'
-      owner: 'deploy'
-      group: '{{ project_user }}'
-  when: qa is defined
-- name: if on qa, set acls appropriately so apache can access
-  acl:
-      entity: apache
-      etype: group
-      permissions: rwx
-      path: '{{ media_root }}'
-      recursive: yes
-      default: yes
-      state: present
-  when: qa is defined
-- name: Give deploy acl rwx over all files in the directory as a fall back
-  acl:
-      entity: deploy
-      etype: user
-      permissions: rwx
-      path: '{{ media_root }}'
-      recursive: yes
-      default: yes
-      state: present
-- name: Configure selinux permissions (using command to be non-su safe)
-  # selinux settings should be made at the server level
-  shell: '/usr/sbin/restorecon -R {{ media_root }}'
-  args:
-    executable: /bin/bash
+- name: Configure media folder and set up Django configurations
+  block:
+    - name: Create media root if it does not already exist
+      file:
+          path: '{{ media_root }}'
+          state: directory
+          mode: "u=rwX,g=rwX,o=X"
+          recurse: yes
+    - name: If on qa, set folder to the appropriate project user instead
+      file:
+          path: '{{ media_root }}'
+          owner: 'deploy'
+          group: '{{ project_user }}'
+      when: qa is defined
+    - name: if on qa, set acls appropriately so apache can access
+      acl:
+          entity: apache
+          etype: group
+          permissions: rwx
+          path: '{{ media_root }}'
+          recursive: yes
+          default: yes
+          state: present
+      when: qa is defined
+    - name: Give deploy acl rwx over all files in the directory as a fall back
+      acl:
+          entity: deploy
+          etype: user
+          permissions: rwx
+          path: '{{ media_root }}'
+          recursive: yes
+          default: yes
+          state: present
+    - name: Configure selinux permissions (using command to be non-su safe)
+      # selinux settings should be made at the server level
+      shell: '/usr/sbin/restorecon -R {{ media_root }}'
+      args:
+        executable: /bin/bash
+  rescue:
+    - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/create_deployment/tasks/fail.yml
+++ b/roles/create_deployment/tasks/fail.yml
@@ -1,0 +1,3 @@
+- name: Force an unhandled failure to stop deploy
+  fail:
+      msg: "Deploy did not complete successfully."

--- a/roles/create_deployment/tasks/fail.yml
+++ b/roles/create_deployment/tasks/fail.yml
@@ -9,6 +9,7 @@
           description: "Deployment failed, check Ansible logs"
       headers:
           Authorization: "token {{ github_token }}"
+  when: deployment is defined
 - name: Force an unhandled failure to stop deploy
   fail:
       msg: "Deploy did not complete successfully."

--- a/roles/create_deployment/tasks/fail.yml
+++ b/roles/create_deployment/tasks/fail.yml
@@ -1,3 +1,14 @@
+- name: Close a deploy as a failure
+  uri:
+      url: '{{ deployment.json.url }}/statuses'
+      body_format: json
+      method: POST
+      status_code: 201
+      body:
+          state: "error"
+          description: "Deployment failed, check Ansible logs"
+      headers:
+          Authorization: "token {{ github_token }}"
 - name: Force an unhandled failure to stop deploy
   fail:
       msg: "Deploy did not complete successfully."

--- a/roles/create_deployment/tasks/main.yml
+++ b/roles/create_deployment/tasks/main.yml
@@ -1,4 +1,8 @@
-## Create a GitHub Deployment
+###
+# Create a GitHub deployment for project and set its status to pending.
+# Requires close_deployment task to be added also to close deployment as
+# a success.
+###
 - name: Create a GitHub deployment
   block:
     - name: Check for GitHub token, and fail if not present
@@ -31,5 +35,5 @@
           description: "Deployment in progress"
         headers:
           Authorization: "token {{ github_token }}"
-  rescue:
-        - include_tasks: roles/create_deployment/tasks/fail.yml
+# No rescue because again, if either of these fail, the error status will
+# likely also fail out.

--- a/roles/create_deployment/tasks/main.yml
+++ b/roles/create_deployment/tasks/main.yml
@@ -5,8 +5,31 @@
       fail:
           msg: "Pass a GitHub API token to -e github_token or set in environment as ANSIBLE_GITHUB_TOKEN"
       when: github_token == ""
-    - name: Just fail to prevent this from actually doing anything at all.
-      fail:
-          msg: "Hard stop"
+    - name: Create a deployment
+      uri:
+        url: '{{ deployments_endpoint }}'
+        body_format: json
+        method: POST
+        status_code: 201
+        body:
+          ref: '{{ gitref }}'
+          environment: '{{ deploy_environment }}'
+          description: '{{ deploy_description }}'
+          auto_merge: false
+        headers:
+          Authorization: "token {{ github_token }}"
+        return_content: true
+      register: deployment
+    - name: Set status to in progress
+      uri:
+        url: '{{ deployment.json.url }}/statuses'
+        body_format: json
+        method: POST
+        status_code: 201
+        body:
+          state: "pending"
+          description: "Deployment in progress"
+        headers:
+          Authorization: "token {{ github_token }}"
   rescue:
         - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/create_deployment/tasks/main.yml
+++ b/roles/create_deployment/tasks/main.yml
@@ -1,0 +1,12 @@
+## Create a GitHub Deployment
+- name: Create a GitHub deployment
+  block:
+    - name: Check for GitHub token, and fail if not present
+      fail:
+          msg: "Pass a GitHub API token to -e github_token or set in environment as ANSIBLE_GITHUB_TOKEN"
+      when: github_token == ""
+    - name: Just fail to prevent this from actually doing anything at all.
+      fail:
+          msg: "Hard stop"
+  rescue:
+        - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/django_collectstatic/tasks/main.yml
+++ b/roles/django_collectstatic/tasks/main.yml
@@ -1,8 +1,12 @@
 ###
 # Run Django's collectstatic command
 ###
-- name: Run manage.py collectstatic
-  django_manage:
-    command: collectstatic
-    app_path: "{{ deploy }}"
-    virtualenv: "{{ deploy }}/env"
+- name: Run collectstatic and any associated tasks
+  block:
+    - name: Run manage.py collectstatic
+      django_manage:
+        command: collectstatic
+        app_path: "{{ deploy }}"
+        virtualenv: "{{ deploy }}/env"
+  rescue:
+    - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/django_compressor/tasks/main.yml
+++ b/roles/django_compressor/tasks/main.yml
@@ -6,14 +6,18 @@
 # so that Apache can use the result.
 ###
 # Ownership needs to deploy/apache for production
-- name: Configure CACHE for django-compressor
-  file:
-    path: '{{ deploy }}/static/CACHE'
-    state: directory
-    owner: deploy
-    group: apache
-- name: run ./manage.py compress to build CSS
-  django_manage:
-    command: compress
-    app_path: "{{ deploy }}"
-    virtualenv: "{{ deploy }}/env"
+- name: Configure for django compressor
+  block:
+    - name: Configure CACHE for django-compressor
+      file:
+        path: '{{ deploy }}/static/CACHE'
+        state: directory
+        owner: deploy
+        group: apache
+    - name: run ./manage.py compress to build CSS
+      django_manage:
+        command: compress
+        app_path: "{{ deploy }}"
+        virtualenv: "{{ deploy }}/env"
+  rescue:
+    - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/django_migrate/tasks/main.yml
+++ b/roles/django_migrate/tasks/main.yml
@@ -1,8 +1,11 @@
 ###
 # Run Django database migrations, must be after installing local_settings
 ###
-- name: Run database migrations
-  django_manage:
-    command: migrate
-    app_path: "{{ deploy }}"
-    virtualenv: "{{ deploy }}/env"
+- block:
+    - name: Run database migrations
+      django_manage:
+        command: migrate
+        app_path: "{{ deploy }}"
+        virtualenv: "{{ deploy }}/env"
+  rescue:
+    - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/finalize_deploy/tasks/main.yml
+++ b/roles/finalize_deploy/tasks/main.yml
@@ -48,16 +48,5 @@
       shell: '/usr/sbin/restorecon -R {{ install_root }}'
       args:
         executable: /bin/bash
-    - name: Close GitHub deployment as a success.
-      uri:
-          url: '{{ deployment.json.url }}/statuses'
-          body_format: json
-          method: POST
-          status_code: 201
-          body:
-              state: "success"
-              description: "Deployment succeeded"
-          headers:
-              Authorization: "token {{ github_token }}"
   rescue:
     - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/finalize_deploy/tasks/main.yml
+++ b/roles/finalize_deploy/tasks/main.yml
@@ -5,44 +5,48 @@
 # It assumes the standard configuration /srv/www symlinks to /var/www
 # used in CDH Django projects.
 ---
-- name: Check for "current" symlink; if present, save path
-  stat:
-    path: "{{ install_root }}/current"
-  register: previous
-- name: Set current symlink
-  file:
-    src: "{{ deploy }}"
-    dest: "{{ install_root }}/current"
-    state: link
-- name: Create "current" symlink for new deploy
-  stat:
-    path: "{{ install_root }}/current"
-  register: current
-- name: If deploy path differs from last "current", update "previous" symlink
-  file:
-    src: "{{ previous.stat.lnk_target }}"
-    dest: "{{ install_root }}/previous"
-    state: link
-  when: >
-    previous.stat.exists == True and
-    previous.stat.lnk_source != current.stat.lnk_source
-- name: Register there is now a previous symlink
-  stat:
-    path: "{{ install_root }}/previous"
-  register: previous
-- name: Update /var/www/ symlink to make the new version live
-  file:
-    src: "{{ deploy }}"
-    dest: "/var/www/{{ symlink }}"
-    state: link
+- name: Do final configurations and restart apache
+  block:
+    - name: Check for "current" symlink; if present, save path
+      stat:
+        path: "{{ install_root }}/current"
+      register: previous
+    - name: Set current symlink
+      file:
+        src: "{{ deploy }}"
+        dest: "{{ install_root }}/current"
+        state: link
+    - name: Create "current" symlink for new deploy
+      stat:
+        path: "{{ install_root }}/current"
+      register: current
+    - name: If deploy path differs from last "current", update "previous" symlink
+      file:
+        src: "{{ previous.stat.lnk_target }}"
+        dest: "{{ install_root }}/previous"
+        state: link
+      when: >
+        previous.stat.exists == True and
+        previous.stat.lnk_source != current.stat.lnk_source
+    - name: Register there is now a previous symlink
+      stat:
+        path: "{{ install_root }}/previous"
+      register: previous
+    - name: Update /var/www/ symlink to make the new version live
+      file:
+        src: "{{ deploy }}"
+        dest: "/var/www/{{ symlink }}"
+        state: link
 
-# This makes sure that any server side settings that handle autoconfiguring
-# SELinux permissions (that we would otherwise need to be root for) are
-# put in place on newly created directories
+    # This makes sure that any server side settings that handle autoconfiguring
+    # SELinux permissions (that we would otherwise need to be root for) are
+    # put in place on newly created directories
 
-# It uses the shell modules rather than the SELinux or Apache modules
-# because we only have limited sudo and rights for both these statements
-- name: Call restorecon to set permissions for install_root
-  shell: '/usr/sbin/restorecon -R {{ install_root }}'
-  args:
-    executable: /bin/bash
+    # It uses the shell modules rather than the SELinux or Apache modules
+    # because we only have limited sudo and rights for both these statements
+    - name: Call restorecon to set permissions for install_root
+      shell: '/usr/sbin/restorecon -R {{ install_root }}'
+      args:
+        executable: /bin/bash
+  rescue:
+    - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/finalize_deploy/tasks/main.yml
+++ b/roles/finalize_deploy/tasks/main.yml
@@ -48,5 +48,16 @@
       shell: '/usr/sbin/restorecon -R {{ install_root }}'
       args:
         executable: /bin/bash
+    - name: Close GitHub deployment as a success.
+      uri:
+          url: '{{ deployment.json.url }}/statuses'
+          body_format: json
+          method: POST
+          status_code: 201
+          body:
+              state: "success"
+              description: "Deployment succeeded"
+          headers:
+              Authorization: "token {{ github_token }}"
   rescue:
     - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/finalize_staging/tasks/main.yml
+++ b/roles/finalize_staging/tasks/main.yml
@@ -7,8 +7,11 @@
 # (the server does not report its IP as 'localhost' or a princeton.edu domain
 # and therefore fails to validate).
 ###
-- name: Add a django superuser since CAS won't work behind Vagrant forward
-  django_manage:
-    command: "loaddata /vagrant/admin_user.json"
-    app_path: "{{ deploy }}"
-    virtualenv: "{{ deploy }}/env"
+- block:
+    - name: Add a django superuser since CAS won't work behind Vagrant forward
+      django_manage:
+        command: "loaddata /vagrant/admin_user.json"
+        app_path: "{{ deploy }}"
+        virtualenv: "{{ deploy }}/env"
+  rescue:
+    - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/install_local_settings/tasks/main.yml
+++ b/roles/install_local_settings/tasks/main.yml
@@ -4,19 +4,23 @@
 # that should appear in group_vars/ for the particular project
 #
 ###
-- name: Install local_settings.py from project template
-  template:
-    src: 'templates/{{ template_path }}/local_settings.py'
-    dest: '{{ deploy }}/{{ django_app }}/local_settings.py'
-- name: Set permissions on local_settings to be unreadable by other
-  file:
-    path: '{{ deploy }}/{{ django_app }}/local_settings.py'
-    mode: u+rw,g+r,o-rwx
-- name: For QA, setfacl so that the Django project group can read it too
-  acl:
-    path: '{{ deploy }}/{{ django_app }}/local_settings.py'
-    entity: '{{ project_user }}'
-    etype: group
-    permissions: r
-    state: present
-  when: qa is defined
+- name: Install local_settings in Django project
+  block:
+    - name: Install local_settings.py from project template
+      template:
+        src: 'templates/{{ template_path }}/local_settings.py'
+        dest: '{{ deploy }}/{{ django_app }}/local_settings.py'
+    - name: Set permissions on local_settings to be unreadable by other
+      file:
+        path: '{{ deploy }}/{{ django_app }}/local_settings.py'
+        mode: u+rw,g+r,o-rwx
+    - name: For QA, setfacl so that the Django project group can read it too
+      acl:
+        path: '{{ deploy }}/{{ django_app }}/local_settings.py'
+        entity: '{{ project_user }}'
+        etype: group
+        permissions: r
+        state: present
+      when: qa is defined
+  rescue:
+    - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/prep_staging/tasks/main.yml
+++ b/roles/prep_staging/tasks/main.yml
@@ -3,43 +3,47 @@
 # correctly templated configuration for the Virtualhost and wsgi.
 ###
 ---
-- name: Install a global postcss for projects that need it
-  npm:
-    name: '{{ item }}'
-    global: yes
-  with_items:
-      - postcss-cli
-      - autoprefixer
-  # we ignore the error if it doesn't work in case we're working with a play
-  # that doesn't have node installed and on path
-  ignore_errors: yes
-- name: Create vhost configuration
-  template:
-    src: '{{ templates_dir }}/staging_vagrant/apache_vhost.conf'
-    dest: /etc/httpd/conf.d/apache_vhost.conf
-- name: Create directory for wsgi settings
-  file:
-    state: directory
-    dest: /etc/httpd/conf.d/staging
-    owner: root
-    group: root
-- name: Create wsgi configuration
-  template:
-    src: '{{ templates_dir }}/staging_vagrant/apache_wsgi.conf'
-    dest: /etc/httpd/conf.d/staging/wsgi.conf
-- name: Clear /var/www/ and /srv/www
-  shell: 'rm -rf /var/www/* && rm -rf /srv/www/*'
-  args:
-    executable: /bin/bash
-    warn: false
-  when: clear_staging
-- name: Remove staging db if exists
-  mysql_db:
-    name: staging
-    state: absent
-  when: clear_staging
-- name: Create staging db
-  mysql_db:
-    name: staging
-    state: present
-    encoding: utf8
+- name: Prepare staging VM for a run
+  block:
+    - name: Install a global postcss for projects that need it
+      npm:
+        name: '{{ item }}'
+        global: yes
+      with_items:
+          - postcss-cli
+          - autoprefixer
+      # we ignore the error if it doesn't work in case we're working with a play
+      # that doesn't have node installed and on path
+      ignore_errors: yes
+    - name: Create vhost configuration
+      template:
+        src: '{{ templates_dir }}/staging_vagrant/apache_vhost.conf'
+        dest: /etc/httpd/conf.d/apache_vhost.conf
+    - name: Create directory for wsgi settings
+      file:
+        state: directory
+        dest: /etc/httpd/conf.d/staging
+        owner: root
+        group: root
+    - name: Create wsgi configuration
+      template:
+        src: '{{ templates_dir }}/staging_vagrant/apache_wsgi.conf'
+        dest: /etc/httpd/conf.d/staging/wsgi.conf
+    - name: Clear /var/www/ and /srv/www
+      shell: 'rm -rf /var/www/* && rm -rf /srv/www/*'
+      args:
+        executable: /bin/bash
+        warn: false
+      when: clear_staging
+    - name: Remove staging db if exists
+      mysql_db:
+        name: staging
+        state: absent
+      when: clear_staging
+    - name: Create staging db
+      mysql_db:
+        name: staging
+        state: present
+        encoding: utf8
+  rescue:
+    - include_tasks: roles/create_deployment/tasks/fail.yml

--- a/roles/restart_httpd/tasks/main.yml
+++ b/roles/restart_httpd/tasks/main.yml
@@ -5,7 +5,10 @@
 # Ansible user does not have full super user access to use the become directive,
 # so it runs using the command module rather than privilege elevation.
 ###
-- name: Restart httpd24
-  command: "sudo systemctl restart httpd24-httpd"
-  args:
-    warn: false
+- block:
+    - name: Restart httpd24
+      command: "sudo systemctl restart httpd24-httpd"
+      args:
+        warn: false
+  rescue:
+     - include_tasks: roles/create_deployment/tasks/fail.yml


### PR DESCRIPTION
This pull request:

- [ ] Adds GitHub deployment roles `create_deployment` and `close_deployment`
- [ ] Inserts error handing into all tasks that enables the deployment to report an error on task failure and then bail out as normal using `block` and `rescue` and an included task from `create_deployment` role
- [ ] Configures mep and ppa qa to use the new roles as examples.
- [ ] Documents environmental variable or commandline options for GitHub token.

Intended functionality:

1. Ansible creates a deployment in the name of the person who owns the GitHub token
2. Notifies that deploy is pending by settings its status using the GitHub API
3. Closes the deployment as a success if successful, and in all other cases, sets it as error.
