### PR TITLE
Add deploy bash wrapper for QOL improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,24 @@ for secrets in a `local_settings.py`, but prevents worst case scenarios from
 emerging.
 
 
+### Running a deploy
+
+To make running deployments easier, you can use the provided `deploy` script
+to wrap `ansible-playbook`. By default, `deploy` switches you to `master`,
+runs `git pull` and checks for uncommited changes to files, etc. If any appear,
+it aborts.
+
+Once you have loaded your virtual environment, you may use it to wrap a
+deploy more safely with all of the parmaters passed
+as if for `ansible-playbook`:
+
+```{bash}
+./deploy name_of_playbook.yml arg1=foo
+```
+
+If the `./` is annoying, you can `ln -s `pwd`/deploy /path/to/virtualenv/bin/`
+to add it to your `$PATH` while the virtual environment is loaded.
+
 ### Running a playbook
 
 To run a playbook, from your virtual environment, simply invoke:

--- a/deploy
+++ b/deploy
@@ -1,0 +1,58 @@
+#!/bin/bash
+# This simple script wraps ansible playbook and passes argument along
+# such that master is checked out and a git pull occurs.
+
+# It also attempts to make sure you don't have unstaged or uncommitted files
+# lest they pollute a run. If you want to do that, run ansible-playbook manually
+
+
+# Usage: ./deploy <ansible-playbook args>
+
+# Checkout master and then git pull to get latest changes
+if ! git checkout master
+then
+    exit 1
+fi
+git pull
+if [ $? -ne 0 ]
+then
+    exit 1
+fi
+
+
+# Update the index
+git update-index -q --ignore-submodules --refresh
+
+# check for unstaged changes
+if ! git diff-files --quiet --ignore-submodules --
+then
+    cat >&2 <<EOM
+You have unstaged changes.
+Please commit them or run ansible-playbook manually.
+EOM
+    exit 1
+fi
+
+# check index containing uncommited files.
+if ! git diff-index --cached --quiet HEAD --ignore-submodules --
+then
+    cat >&2 <<EOM
+Your index contain uncommited files.
+Please commit them or run ansible-playbook manually.
+EOM
+    exit 1
+fi
+
+
+# check for files not added to index or otherwise committed.
+if [ ! -z `git ls-files --other --directory --exclude-standard` ]
+then
+    cat >&2 <<-EOM
+You have uncommited files in the repository that are not gitignored.
+Please commit them or run ansible-playbook manually.
+EOM
+    exit 1
+fi
+
+# At last, if everything is good, run ansible-playbook with args as passed
+ansible-playbook "$@"


### PR DESCRIPTION
This PR adds a wrapper command `deploy` that can be used to make deployments to QA/Prod more clearly and easily pull latest changes from `master` and use them.