### PR TITLE
Add bash script to pull production databases to QA

### DIFF
--- a/scripts/sync_prod
+++ b/scripts/sync_prod
@@ -61,6 +61,10 @@ if [[ storageDir == "null" ]]
   then
     storageDir=${PWD}
 fi
+
+# create a storage dir just in case it doesn't exist
+mkdir -p "${storageDir}"
+
 # This loop avoids issues with spaces in values, although they probably
 # shouldn't be there in the first place
 while IFS= read -r line
@@ -77,7 +81,7 @@ do
       echo "Missing host or database key in ${i}." 1>&2
       exit 1
   fi
-  # On a dry run, just say what it ough tto connect to
+  # On a dry run, just say what it ought to connect to
   # and also what files would be deleted based on the configured
   # storageDir
   if  [[ $dryrun ]]
@@ -89,8 +93,9 @@ do
   else
     # Otherwise, connect to host, dump to tmp file
     echo "Connecting to ${host}..."
-    ssh -o ConnectTimeout=5 "${host}" mysqldump --opt "${db}" > "${tmp_file}"
-    retVal=$?
+    # continue on an error but set an error code so we know there was a problem
+    ssh -o ConnectTimeout=5 \
+    "${host}" mysqldump --opt "${db}" > "${tmp_file}" || EXIT_CODE=$? && true
     if [[ $retVal -ne 0 ]]
       then
         echo "Could not dump database $db for $host" 1>&2
@@ -108,5 +113,35 @@ do
   fi
 done
 
-# if SSH error was logged, bubble it up via exit code.
+# dump files
+for i in "${applications[@]}"
+do
+  mediaDir=$(echo ${i} | jq -r ".mediaDir")
+  host=$(echo ${i} | jq -r ".host")
+  # no mediaDir specified or empty string
+  if [[ $mediaDir == "null" ]] || [[ -z $mediaDir  ]]
+    then
+      continue
+  fi
+
+  if [[ $dryrun ]]
+    then
+      echo "Would rsync ${mediaDir} as ${storageDir}/media/${host}."
+  else
+    echo "Rsyncing media for ${host}"
+    # make sure the folder exists
+    mkdir -p "${storageDir}/media/${host}"
+    # rsync over the files and maintain a link
+    # continue on an error but set an error code so we know there was a problem
+    rsync -r "${host}:${mediaDir}" "${storageDir}/media/${host}/" || EXIT_CODE=$? && true
+    if [[ $retVal -ne 0 ]]
+      then
+        echo "Could not rsync media for $host" 1>&2
+        error=true
+        break
+    fi
+  fi
+done
+
+# if SSH or rsync error was logged, bubble it up via exit code.
 if [[ $error ]]; then exit 1; fi

--- a/scripts/sync_prod
+++ b/scripts/sync_prod
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# sync_prod - 0.1
+#
+#
+# sync_prod is a utility to sync database dumps from production and and to
+# sync media files (if applicable) for a Django application that are
+# user managed (i.e. uploaded photos for a CMS). Assumes that a proper
+# .my.cnf with credentials exists on target hosts for mysqldump.
+#
+# Dependencies:
+# - jq (system install via package manager for JSON parsing)
+#
+# Usage: sync_prod [-h] [-d] config.json
+# -h    Display this help message
+# -d    Dry-run
+
+printUsage() {
+  echo "Usage: ${0} [-h] [-d] config.json"
+  echo "-h    Display this help message"
+  echo "-d    Dry-run"
+}
+
+# Parse usage option flags, with \? as a backstop against invalid options.
+while getopts ":hd" opt; do
+  case ${opt} in
+    h )
+      printUsage
+      exit 0
+      ;;
+    d )
+      dryrun=true
+      ;;
+    \? )
+      echo "Invalid option: -${OPTARG}" 1>&2
+      printUsage 1>&2
+      exit 1
+      ;;
+  esac
+done;
+# Shift past any options that were consumed
+shift $((OPTIND -1))
+
+# Check if there is still a path to config.json
+if [ -z "${1}" ]
+    then
+      echo "No config file supplied."
+      echo ""
+      printUsage 1>&2
+      exit 1
+fi
+
+# Configurations
+config="$1"
+# Use tmp for temporary dumps
+tmp_file=/tmp/db_tmp.sql
+applications=()
+# Get configured storage dir, or if not, assume PWD
+storageDir=$(jq -r ".storageDir" "${config}")
+if [[ storageDir == "null" ]]
+  then
+    storageDir=${PWD}
+fi
+# This loop avoids issues with spaces in values, although they probably
+# shouldn't be there in the first place
+while IFS= read -r line
+do
+  applications+=( "${line}" )
+done < <( jq -c ".applications | .[]" "${config}" )
+
+for i in "${applications[@]}"
+do
+  host=$(echo ${i} | jq -r ".host")
+  db=$(echo ${i} | jq -r ".database")
+  if [[ $host = "null" ]] || [[ $db = "null" ]]
+    then
+      echo "Missing host or database key in ${i}." 1>&2
+      exit 1
+  fi
+  # On a dry run, just say what it ough tto connect to
+  # and also what files would be deleted based on the configured
+  # storageDir
+  if  [[ $dryrun ]]
+    then
+      echo "Would connect to host: $host, database: ${db}"
+      find "${storageDir}" -maxdepth 1 -type f -iname "*-${db}.sql" \
+      -exec echo "Would delete: " {} \;
+
+  else
+    # Otherwise, connect to host, dump to tmp file
+    echo "Connecting to ${host}..."
+    ssh -o ConnectTimeout=5 "${host}" mysqldump --opt "${db}" > "${tmp_file}"
+    retVal=$?
+    if [[ $retVal -ne 0 ]]
+      then
+        echo "Could not dump database $db for $host" 1>&2
+        error=true
+        break
+    fi
+    dateString=$(date +%Y-%m-%d)
+    dumpName="${dateString}-${db}.sql"
+    # find a previously labeled file with a different/same date
+    # and delete it.
+    find "${storageDir}" -maxdepth 1 -type f -iname "*-${db}.sql" \
+    -exec rm -f {} \;
+    # Move the tmp file in and give it a YYYY-MM-DD-db.sql name
+    mv "${tmp_file}" "${storageDir}/${dumpName}"
+  fi
+done
+
+# if SSH error was logged, bubble it up via exit code.
+if [[ $error ]]; then exit 1; fi


### PR DESCRIPTION
This script pulls production databases and production media based on `config.json` to the QA server (or any other server so configured) from production servers.