### PR TITLE
Initial playbook for PEMM QA deploy

### DIFF
--- a/group_vars/pemm/vars.yml
+++ b/group_vars/pemm/vars.yml
@@ -1,0 +1,24 @@
+###
+# Variables for PEMM that apply across all deploy groups (prod, qa, and staging)
+###
+---
+# do we still need these for ubuntu? should use python3.6
+# Using python35 and nodejs8 for QA and staging
+# Paths are picky and spaces for any YAML multiline syntax causes issues
+#path: '/opt/rh/rh-python35/root/usr/bin:/opt/rh/rh-nodejs8/root/usr/bin:{{ ansible_env.PATH }}'
+#ld_library_path: '/opt/rh/rh-python35/root/usr/lib64:/opt/rh/rh-nodejs8/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
+#python_path: '/opt/rh/rh-nodejs8/root/usr/lib/python2.7/site-packages{% if ansible_env.PYTHON_PATH is defined %}:{{ ansible_env.PYTHONPATH }}{% endif %}'
+# GitHub repository
+repo: 'Princeton-CDH/pemm-scripts'
+# name of python application
+django_app: scripts
+# application name
+app_name: pemm
+# apache symlink
+symlink: "{{ app_name }}"
+# Solr settings
+solr_collection: pemm
+# apache location
+apache_app_path: "/var/www/{{ app_name }}"
+# wsgi file relative to apache location
+wsgi_path: "scripts/pemm.wsgi"

--- a/group_vars/pemm_qa/vars.yml
+++ b/group_vars/pemm_qa/vars.yml
@@ -1,0 +1,7 @@
+app_vars:
+  - name: PEMM_SOLR_URL
+    value: 'https://test-index.cdh.princeton.edu/'
+  - name: PEMM_SOLR_CORE
+    value: 'pemm'
+  - name: FLASK_APP
+    value: 'scripts/server.py'

--- a/hosts
+++ b/hosts
@@ -81,6 +81,16 @@ mep_qa
 mep_prod
 mep_staging
 
+[pemm_qa]
+test-pemm.cdh.princeton.edu
+[pemm_prod]
+pemm.cdh.princeton.edu
+
+[pemm:children]
+pemm_qa
+pemm_prod
+
+
 ### staging, prod, and qa stanzas to create shared groups
 [staging:children]
 winthrop_staging

--- a/hosts
+++ b/hosts
@@ -82,9 +82,9 @@ mep_prod
 mep_staging
 
 [pemm_qa]
-test-pemm.cdh.princeton.edu
+cdh-test-pemm1.princeton.edu
 [pemm_prod]
-pemm.cdh.princeton.edu
+cdh-pemm1.princeton.edu
 
 [pemm:children]
 pemm_qa

--- a/pemm_qa.yml
+++ b/pemm_qa.yml
@@ -1,0 +1,19 @@
+- hosts: pemm_qa
+  connection: ssh
+  remote_user: deploy
+  # environment:
+  #   PATH: '{{ path }}'
+  #   LD_LIBRARY_PATH: '{{ ld_library_path }}'
+  #   PYTHONPATH: '{{ python_path }}'
+  roles:
+    - create_deployment
+    - install_app_config
+    - build_project_repo
+    - build_virtualenv
+    - configure_apache
+    # - restart_httpd   # handled by configure apache ?
+    - close_deployment
+
+# cron tab management still to do
+
+

--- a/pemm_qa.yml
+++ b/pemm_qa.yml
@@ -12,6 +12,7 @@
     - build_virtualenv
     - configure_apache
     # - restart_httpd   # handled by configure apache ?
+    - finalize_deploy
     - close_deployment
 
 # cron tab management still to do

--- a/roles/build_project_repo/tasks/main.yml
+++ b/roles/build_project_repo/tasks/main.yml
@@ -20,7 +20,7 @@
         version: '{{ gitref }}'
       # register repo_info for group_vars
       register: repo_info
-    - name: Get version information from __init__.py for Django projects
+    - name: Get version information from __init__.py for Python projects
       # This script is present in get_ver.py, and should be safe for all
       # system pythons greater than 2.
       script: get_ver.py {{ clone_root}}/{{ repo }} {{ django_app }}

--- a/roles/configure_apache/defaults/main.yml
+++ b/roles/configure_apache/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+apache:
+    docroot: '{{apache_app_path |default("/var/www/html")}}'
+    servername: "{{ ansible_hostname }}"
+    directory_options: ''
+apache_listen_port: 80

--- a/roles/configure_apache/handlers/main.yml
+++ b/roles/configure_apache/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: restart apache
+  service:
+    name: apache2
+    enabled: true
+    state: restarted
+
+- name: reload apache
+  service:
+    name: apache2
+    state: reloaded

--- a/roles/configure_apache/tasks/main.yml
+++ b/roles/configure_apache/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+
+- name: ensure required packages are present
+  apt:
+    name: ['apache2', 'libapache2-mod-wsgi']
+    state: present
+    update_cache: true
+
+- name: install apache modules
+  apache2_module:
+    name: "{{ item }}"
+    state: present
+  notify: restart apache
+  # with_items:
+  #   - rewrite
+  #   - headers
+  #   - expires
+  #   - filter
+  #   - vhost_alias
+
+- name: update listen port if needed
+  replace:
+    path: /etc/apache2/ports.conf
+    regexp: 'Listen 80$'
+    replace: "Listen {{ apache_listen_port }}"
+
+# - name: check for update of config needed
+#   lineinfile:
+#     dest: "/etc/apache2/sites-available/000-default.conf"
+#     line: "    DocumentRoot {{ apache.docroot }}"
+#     state: present
+#   check_mode: yes
+#   register: update_config
+
+- name: modify the default apache site
+  template:
+    src: "vhosts24.conf.j2"
+    dest: "/etc/apache2/sites-available/000-default.conf"
+  when: update_config.msg == "line added"
+  notify: restart apache

--- a/roles/configure_apache/templates/vhosts24.conf.j2
+++ b/roles/configure_apache/templates/vhosts24.conf.j2
@@ -1,0 +1,18 @@
+# Default Apache virtualhost template this config file in {{ ansible_managed }}
+
+<VirtualHost *:{{ apache_listen_port }}>
+    ServerAdmin webmaster@localhost
+    DocumentRoot {{ apache.docroot }}
+    ServerName {{ apache.servername }}
+
+    WSGIDaemonProcess {{ app_name }} group={{ app_name }} python-path={{ apache_app_path }}/env/lib/python3.6/site-packages:{{ apache_app_path }} processes=1 threads=2
+    WSGIScriptAlias / {{ apache_app_path }}/{{ wsgi_path }}
+
+    <Directory {{ apache_app_path }}>
+        WSGIProcessGroup {{ app_name }}
+        WSGIApplicationGroup %{GLOBAL}
+        Order deny,allow
+        Allow from all
+    </Directory>
+</VirtualHost>
+

--- a/roles/install_app_config/tasks/main.yml
+++ b/roles/install_app_config/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Create app_configs directory
+  file:
+    path: '/home/{{ deploy_user }}/app_configs'
+    state: 'directory'
+    owner: '{{ deploy_user }}'
+    group: '{{ deploy_user }}'
+- name: Install app configuration
+  template:
+    src: 'app_config'
+    dest: '/home/{{ deploy_user }}/app_configs/{{ app_name }}'
+    owner: '{{ deploy_user }}'
+    group: '{{ deploy_user }}'
+- name: Load app configs
+  lineinfile: >
+              dest='/home/{{ deploy_user }}/.bashrc'
+              state=present
+              regexp='^for f in ~/app_configs/\*; do source \$f; done$'
+              line="for f in ~/app_configs/*; do source $f; done"
+              insertbefore=BOF

--- a/roles/install_app_config/templates/app_config
+++ b/roles/install_app_config/templates/app_config
@@ -1,0 +1,4 @@
+# environment variables for {{app_name}}
+{% for variable in app_vars %}
+export {{variable.name}}={{variable.value}}
+{% endfor %}


### PR DESCRIPTION
First stab at a playbook to deploy PEMM to a QA ubuntu vm.

Uses a subset of existing roles currently in use for other projects; I expect these will need some modifications in terms of path handling and other things that are specific to SELinux (e.g. `restorecon` call in the finalize deploy).

Adds new roles:
-  `install_app_config` to manage configurations via environment variables in deploy user environment, adapted from pulibrary ansible.
- `configure_apache` to manage apache configuration, adapted from pulibrary ansible