### PR TITLE
use node v10 for cdhweb

### DIFF
--- a/cdh-web.yml
+++ b/cdh-web.yml
@@ -12,6 +12,7 @@
     - build_project_repo
     - build_virtualenv
     - install_local_settings
+    - build_npm
     - configure_media
     - django_collectstatic
     - django_compressor

--- a/cdh-web_qa.yml
+++ b/cdh-web_qa.yml
@@ -12,6 +12,7 @@
     - build_virtualenv
     - configure_logging
     - install_local_settings
+    - build_npm
     - configure_media
     - django_collectstatic
     - django_compressor

--- a/cdh-web_staging.yml
+++ b/cdh-web_staging.yml
@@ -13,6 +13,7 @@
     - build_virtualenv
     - configure_logging
     - install_local_settings
+    - build_npm
     - configure_media
     - django_collectstatic
     - django_compressor

--- a/group_vars/cdh-web/vars.yml
+++ b/group_vars/cdh-web/vars.yml
@@ -14,3 +14,8 @@ symlink: cdh-web
 template_path: cdh-web
 # media_root settings
 media_root: /srv/www/media
+
+# Override default paths to use node v10
+path: '/opt/rh/rh-python35/root/usr/bin:/opt/rh/rh-nodejs10/root/usr/bin:{{ ansible_env.PATH }}'
+ld_library_path: '/opt/rh/rh-python35/root/usr/lib64:/opt/rh/rh-nodejs10/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
+python_path: '/opt/rh/rh-nodejs10/root/usr/lib/python2.7/site-packages{% if ansible_env.PYTHON_PATH is defined %}:{{ ansible_env.PYTHONPATH }}{% endif %}'


### PR DESCRIPTION
- switches cdhweb to use node v10 for QA and production
- enables the `npm install` step (`build_npm` role) for both QA and production deploys

confirmed that node v10 is available in both environments (currently using in QA; installed in prod).