### PR TITLE
Fix replicate permissions for file access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ venv.bak/
 
 # editor configs
 .vscode
+/.ansible

--- a/playbooks/replicate.yml
+++ b/playbooks/replicate.yml
@@ -43,7 +43,6 @@
         path: "{{ media_root }}"
         dest: "{{ media_backup_path }}"
         owner: "{{ deploy_user }}"
-        mode: "0644"
       become: true
       become_user: "{{ deploy_user }}"
       when: media_files.matched|int != 0
@@ -118,6 +117,17 @@
         become: true
         become_user: "{{ deploy_user }}"
         when: media_backup.stat.exists == true
+
+      - name: Set cross-user read permissions on synced backup files
+        ansible.builtin.file:
+          path: "{{ item }}"
+          mode: "0644"
+        become: true
+        become_user: "{{ deploy_user }}"
+        loop:
+          - "{{ dest_backup_path }}"
+          - "{{ dest_media_backup_path }}"
+        when: item is defined
 
       - name: Calculate unzipped db backup path based on backup path
         set_fact:

--- a/roles/postgresql/tasks/backup_db.yml
+++ b/roles/postgresql/tasks/backup_db.yml
@@ -26,10 +26,3 @@
         owner: "{{ application_dbuser_name }}"
         state: "dump"
         target: "{{ db_backup_path }}"
-
-    - name: Set cross-user read permissions on database dump
-      become: true
-      become_user: "{{ deploy_user }}"
-      ansible.builtin.file:
-        path: "{{ db_backup_path }}"
-        mode: "0644"


### PR DESCRIPTION
### Changes: 

Update the permission mode of the files to “0644” to access the media and database dump.

Before the fix, files were only readable by Conan (likely with permissions of 0600 or 0640). However, we SSH as Pulsys instead of directly as Conan, which prevented us from using `scp` to transfer Conan’s files directly.

After the fix, the files now have permissions of “0644,” allowing both Conan and Pulsys users to read them directly.

### Main files:
1. `postgresql/backup_db.yml` - handles DB dump permissions
2. `replicate.yml` - handles media permissions 

