### PR TITLE
[solr] Update path for backups

### DIFF
--- a/roles/solr_collection/defaults/main.yml
+++ b/roles/solr_collection/defaults/main.yml
@@ -13,7 +13,7 @@ solr_backup_date: "{{'%Y%m%d' | strftime(ansible_date_time.epoch) }}"
 # NOTE: backup path for current date is created for us
 # by an existing PUL solr backup cron job.
 # However, they are likely not yet be present for solr9
-solr_backup_location: "/mnt/solr_backup/solr{{ solr_version}}/production/{{ solr_backup_date }}/"
+solr_backup_location: "/solr/data/cloud_backup/solr{{ solr_version}}/production/{{ solr_backup_date }}/"
 solr_backup_filename: "{{ solr_collection }}-{{solr_backup_date}}.bk"
 solr_backup_request_id:  "{{solr_collection }}-{{ansible_date_time.iso8601 }}"
 solr_delete_request_id:  "rm-{{solr_collection }}-{{ansible_date_time.iso8601 }}"


### PR DESCRIPTION
We are now using another directory for backups, which are now sent to Google Cloud via Filesystem in Userspace (FUSE).  See https://github.com/pulibrary/princeton_ansible/pull/6481

**Associated Issue(s):** (not sure, apologies)

### Changes in this PR
_Include all key changes in this pull request_

- Update the path to reflect the new backup directory on solr9 staging boxes.


### Reviewer Checklist
_Include **discrete** checks that should be done by the reviewer beyond looking through
code and/or file changes. Note that this check list will correspond to tasks within
the PR overview page._

- [x] Perhaps try running a playbook with the `solr_backup` tag and make sure it either runs, or at least gets to the next error.
