### PR TITLE
passenger keys for ubuntu expire in january 2026

### DIFF
--- a/roles/passenger/molecule/default/molecule.yml
+++ b/roles/passenger/molecule/default/molecule.yml
@@ -1,6 +1,14 @@
 ---
 scenario:
   name: default
+  test_sequence:
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy
 driver:
   name: docker
 lint: |
@@ -9,14 +17,22 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: pulibrary/puldocker-ubuntu1804-ansible:latest
-    command: ""
+    image: "ghcr.io/pulibrary/vm-builds/ubuntu-22.04"
+    command: "" # image above already has the /sbin/init
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
     pre_build_image: true
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      remote_tmp: /tmp
   log: true
 verifier:
   name: ansible

--- a/roles/passenger/tasks/main.yml
+++ b/roles/passenger/tasks/main.yml
@@ -12,48 +12,102 @@
         nginx_user: "{{ __nginx_user }}"
       when: nginx_user is not defined
 
-    # Passenger repository setup.
-    - name: Add Passenger apt key.
-      tags:
-        - setup
-        - never
-      ansible.builtin.apt_key:
-        keyserver: keyserver.ubuntu.com
-        id: 561F9B9CAC40B2F7
-        state: present
+    - name: Phusion | Ensure keyring directory exists
+      become: true
+      ansible.builtin.file:
+        path: /usr/local/share/keyrings
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+    # Legacy auto-software-signing key (still used to sign the jammy repo)
+    # https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt
+    - name: Phusion | Download legacy auto signing key (SHA1)
+      ansible.builtin.get_url:
+        url: https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt
+        dest: /usr/local/share/keyrings/phusion_passenger_legacy.asc
+        mode: "0644"
+      register: phusion_passenger_legacy_key
 
-    - name: Add apt HTTPS capabilities.
-      tags:
-        - setup
-        - never
-      ansible.builtin.apt:
-        name: apt-transport-https
-        state: present
+    - name: Phusion | Convert legacy key to GPG keyring
+      become: true
+      ansible.builtin.command: >
+        gpg --batch --yes --dearmor
+        -o /usr/local/share/keyrings/phusion_passenger_legacy.gpg
+        /usr/local/share/keyrings/phusion_passenger_legacy.asc
+      when: phusion_passenger_legacy_key.changed
 
-    - name: Add Phusion apt repo.
-      tags:
-        - setup
-        - never
+    - name: Phusion | Install legacy key into apt trusted.gpg.d
+      become: true
+      ansible.builtin.copy:
+        src: /usr/local/share/keyrings/phusion_passenger_legacy.gpg
+        dest: /etc/apt/trusted.gpg.d/phusion.gpg
+        owner: root
+        group: root
+        mode: "0644"
+        remote_src: true
+      when: phusion_passenger_legacy_key.changed
+
+        # phusion new future proof key
+    # https://blog.phusion.nl/important-new-signing-key-for-passenger/
+    # https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key-2025.txt
+    - name: Phusion | use new sha-256 apt key
+      ansible.builtin.get_url:
+        url: https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key-2025.txt
+        dest: /usr/local/share/keyrings/phusion_passenger_2025.asc
+        mode: "0644"
+      register: phusion_passenger_key
+
+    - name: Phusion Passenger | Convert key to GPG keyring
+      ansible.builtin.command:
+        cmd: >
+          gpg --batch --yes --dearmor
+          -o /usr/local/share/keyrings/phusion_passenger_2025.gpg
+          /usr/local/share/keyrings/phusion_passenger_2025.asc
+      when: phusion_passenger_key.changed
+
+    - name: Phusion Passenger | Install key into apt trusted.gpg.d
+      ansible.builtin.copy:
+        src: /usr/local/share/keyrings/phusion_passenger_2025.gpg
+        dest: /etc/apt/trusted.gpg.d/phusion_new.gpg
+        owner: root
+        group: root
+        mode: "0644"
+        remote_src: true
+      when: phusion_passenger_key.changed
+
+    - name: Phusion | Add Phusion apt repo.
       ansible.builtin.apt_repository:
         repo: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger {{ ansible_distribution_release }} main'
         state: present
-        # ignore_errors: true
+        filename: passenger
+        update_cache: false
 
-    - name: Add key for Phusion apt repo
-      tags:
-        - setup
-        - never
-      ansible.builtin.apt_key:
-        keyserver: keyserver.ubuntu.com
-        id: 561F9B9CAC40B2F7
+    - name: Passenger | Clean apt cache
+      ansible.builtin.command: apt-get clean
+      changed_when: false
 
-    - name: Update our repositories
-      tags:
-        - setup
-        - never
-      become: true
-      ansible.builtin.apt:
-        update_cache: true
+    - name: Passenger | Update apt cache after adding repository
+      ansible.builtin.command: apt-get update
+      register: cache_update
+      retries: 3
+      delay: 5
+      until: cache_update.rc == 0
+      changed_when: false
+      failed_when: false
+
+    - name: Passenger | Display cache update errors
+      ansible.builtin.debug:
+        msg: |
+          Return code: {{ cache_update.rc }}
+          STDOUT: {{ cache_update.stdout }}
+          STDERR: {{ cache_update.stderr }}
+      when: cache_update.rc != 0
+
+    - name: Passenger | Fail if cache update failed
+      ansible.builtin.fail:
+        msg: "apt-get update failed. See debug output above."
+      when: cache_update.rc != 0
 
     # Nginx and passenger installation.
     - name: Install Nginx and Passenger.


### PR DESCRIPTION
this addresses the change in format for passenger keys related to https://gitlab.lib.princeton.edu/ops/team-handbook/-/issues/204

related to https://github.com/pulibrary/princeton_ansible/pull/6706

**Associated Issue(s):** resolves #

### Changes in this PR
_Include all key changes in this pull request_

- added new keys from passenger
- kept legacy keys
- add now molecule infrastructure


### Notes




### Reviewer Checklist
_Include **discrete** checks that should be done by the reviewer beyond looking through
code and/or file changes. Note that this check list will correspond to tasks within
the PR overview page._

- [ ] Check 1
- [ ] Check 2
