### PR TITLE
remove key addition for conan

### DIFF
--- a/roles/setup/tasks/tigerdata_nfs.yml
+++ b/roles/setup/tasks/tigerdata_nfs.yml
@@ -22,11 +22,3 @@
     create_home: true
     state: present
   tags: [setup, nfs]
-
-- name: Setup - distribute SSH public keys for {{ deploy_user }}
-  ansible.builtin.authorized_key:
-    user: "{{ deploy_user }}"
-    state: present
-    key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
-    exclusive: no
-  tags: [setup, nfs]


### PR DESCRIPTION
this task can run when the ansible controller is a developers laptop but will fail on the ansible automation platform.
The task was added when it was not clear (turned out to NFS was restricted by tigerdata Firewall)

**Associated Issue(s):** resolves #316 

### Changes in this PR
_Include all key changes in this pull request_

removal of task that looks for a public key on the controller

### Notes
_Include any additional notes that will help in the reviewing of this pull request_



### Reviewer Checklist
_Include **discrete** checks that should be done by the reviewer beyond looking through
code and/or file changes. Note that this check list will correspond to tasks within
the PR overview page._

- [ ] run the playbook from your laptop/desktop
- [ ] run from Ansible Tower
