### PR TITLE
added the directory creation task

### DIFF
--- a/roles/prodigy_setup/tasks/main.yml
+++ b/roles/prodigy_setup/tasks/main.yml
@@ -12,6 +12,21 @@
     state: directory
     recurse: no
 
+- name: Ensure muse data and recipe directories exist with write permissions
+  tags:
+    - setup
+    - never
+  become: true
+  file:
+    path: "{{ item }}"
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_user }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - "{{ install_root }}/muse/recipes"
+    - "{{ install_root }}/muse/data"
+
 - name: Create requirements.txt for python requirements
   tags:
     - setup


### PR DESCRIPTION
**Associated Issue(s):** resolves #319 

### Changes in this PR

- Added automated creation task in the `prodigy_setup` role to address permission issues encountered when uploading data and recipe files to the server via SCP
- The task creates `/srv/www/prodigy/muse/recipes` and `/srv/www/prodigy/muse/data` directories with write permissions for the deploy user (`conan`)

### Reviewer Checklist
- [ ] review the code
- [ ] ssh to the VM and test that SCP uploads work after running the playbook with `--tags setup`
