### PR TITLE
TigerData mount fixes + enabled TD for prodigy

### DIFF
--- a/inventory/group_vars/all/vars.yml
+++ b/inventory/group_vars/all/vars.yml
@@ -135,7 +135,7 @@ nfs_domain: "princeton.edu"
 # NOTE: disabled by default; must opt in by host group; requires firewall access
 tigerdata_enabled: false
 tigerdata_nfs_server: "td-mf-cl2.princeton.edu"
-tigerdata_mount_port: 9007
+tigerdata_mount_port: 2049
 tigerdata_cdh_group: "cdh"
 tigerdata_cdh_gid: 30369
 tigerdata_mount_dir: /mnt/tigerdata/cdh

--- a/inventory/group_vars/prodigy/vars.yml
+++ b/inventory/group_vars/prodigy/vars.yml
@@ -24,7 +24,7 @@ running_on_server: true
 # this application does not need NFS
 nfs_enabled: false
 # TODO: Investigate the issue with the TigerData mount
-tigerdata_enabled: false
+tigerdata_enabled: true
 
 # NOTE: Currently need to upload these files manually to each server
 prodigy_datafile: "{{ install_root }}/muse/data/notion-concept-tasks.jsonl"

--- a/roles/setup/tasks/tigerdata_nfs.yml
+++ b/roles/setup/tasks/tigerdata_nfs.yml
@@ -3,14 +3,14 @@
   ansible.builtin.group:
     name: "deploy"
     state: present
-  tags: [setup, nfs]
+  tags: [setup, nfs, never]
 
 - name: Setup - ensure TigerData group "{{ tigerdata_cdh_group }}" exists
   ansible.builtin.group:
     name: "{{ tigerdata_cdh_group }}"
     state: present
     gid: "{{ tigerdata_cdh_gid }}"
-  tags: [setup, nfs]
+  tags: [setup, nfs, never]
 
 - name: Setup - ensure deploy user "{{ deploy_user }}" is provisioned
   ansible.builtin.user:
@@ -21,4 +21,22 @@
     shell: /bin/bash
     create_home: true
     state: present
-  tags: [setup, nfs]
+  tags: [setup, nfs, never]
+
+- name: Setup - ensure system user belongs to TigerData "{{ tigerdata_cdh_group }}" group
+  ansible.builtin.user:
+    name: "pulsys"
+    groups: "{{ tigerdata_cdh_group }}"
+    append: true
+  tags: [setup, nfs, never]
+
+- name: Setup - ensure the presence of TigerData NFS mount
+  ansible.posix.mount:
+    src: "{{ tigerdata_nfs_server }}:/cdh"
+    path: "{{ tigerdata_mount_dir }}"
+    state: mounted
+    fstype: nfs
+    opts: "nfsvers=3,mountport={{ tigerdata_mount_port }},port={{ tigerdata_mount_port }},nolock,proto=tcp"
+  become: true
+  tags: [setup, nfs, never]
+


### PR DESCRIPTION
**Associated Issue(s):** resolves #333 

### Changes in this PR

- Update TigerData mount port
- Update setup role's tigerdata_nfs task so that it adds pul_sys to the TigerData group and ensures TigerData is mounted
- Enables TigerData for Prodigy app

### Notes

- TigerData is enabled for Prodigy primarily for testing purposes
- The Prodigy playbook does not attempt to copy data from TigerData due to TigerData permissions issues