### PR TITLE
run_webpack: use current npm path for geniza

### DIFF
--- a/inventory/group_vars/geniza/vars.yml
+++ b/inventory/group_vars/geniza/vars.yml
@@ -149,3 +149,6 @@ crontab:
 # datadog
 datadog_app_name: cdh_geniza
 
+# npm_for staging
+npm_install_mode: "dev"
+npm_install_path: "/srv/www/geniza/current"

--- a/inventory/group_vars/geniza/vars.yml
+++ b/inventory/group_vars/geniza/vars.yml
@@ -151,4 +151,4 @@ datadog_app_name: cdh_geniza
 
 # npm_for staging
 npm_install_mode: "dev"
-npm_install_path: "/srv/www/geniza/current"
+npm_install_path: "{{ deploy }}"

--- a/roles/build_npm/tasks/main.yml
+++ b/roles/build_npm/tasks/main.yml
@@ -1,13 +1,15 @@
 ---
-
+# roles/build_npm/tasks/main.yml
 - name: Build_npm | Normalize version and select arch
   ansible.builtin.set_fact:
     desired_nodejs_version_v: >-
       {{ (desired_nodejs_version is match('^v')) | ternary(desired_nodejs_version, 'v' ~ desired_nodejs_version) }}
     nodejs_arch: >-
       {{ (ansible_architecture in ['x86_64', 'amd64']) | ternary('x64', 'arm64') }}
-    nodejs_dir: "{{ nodejs_prefix_root | default('/usr/local') }}/node-{{ (desired_nodejs_version is match('^v')) | ternary(desired_nodejs_version, 'v' ~ desired_nodejs_version) }}-linux-{{ (ansible_architecture in ['x86_64','amd64']) | ternary('x64','arm64') }}"
-    nodejs_tarball: "/usr/local/src/node-{{ (desired_nodejs_version is match('^v')) | ternary(desired_nodejs_version, 'v' ~ desired_nodejs_version) }}-linux-{{ (ansible_architecture in ['x86_64','amd64']) | ternary('x64','arm64') }}.tar.xz"
+    nodejs_dir: >-
+      {{ nodejs_prefix_root | default('/usr/local') }}/node-{{ (desired_nodejs_version is match('^v')) | ternary(desired_nodejs_version, 'v' ~ desired_nodejs_version) }}-linux-{{ (ansible_architecture in ['x86_64','amd64']) | ternary('x64','arm64') }}
+    nodejs_tarball: >-
+      /usr/local/src/node-{{ (desired_nodejs_version is match('^v')) | ternary(desired_nodejs_version, 'v' ~ desired_nodejs_version) }}-linux-{{ (ansible_architecture in ['x86_64','amd64']) | ternary('x64','arm64') }}.tar.xz
 
 - name: Build_npm | Check current node (if any)
   ansible.builtin.command: "/usr/local/bin/node --version"
@@ -24,7 +26,6 @@
   become: true
   ansible.builtin.apt:
     name:
-      - build-essential
       - ca-certificates
       - curl
       - tar
@@ -34,7 +35,6 @@
       - zstd
     state: present
     update_cache: true
-
 
 - name: Build_npm | Install Node (prebuilt)
   when: nodejs_needs_install and (nodejs_install_method | default('prebuilt')) == 'prebuilt'
@@ -74,3 +74,24 @@
       register: node_version_check
       changed_when: false
       failed_when: node_version_check.stdout | trim != desired_nodejs_version_v
+
+- name: Build_npm | Verify package.json exists
+  become: true
+  ansible.builtin.stat:
+    path: "{{ npm_install_path }}/package.json"
+  register: pkgjson
+  changed_when: false
+
+- name: Build_npm | Fail if package.json is missing
+  ansible.builtin.fail:
+    msg: "package.json not found at {{ npm_install_path }}; check npm_install_path."
+  when: not (pkgjson.stat.exists | default(false))
+
+- name: Build_npm | Install javascript dependencies with npm
+  become: true
+  become_user: "{{ deploy_user }}"
+  community.general.npm:
+    path: "{{ npm_install_path }}"
+    production: "{{ npm_install_mode == 'production' }}"
+    ci: "{{ npm_install_mode == 'ci' }}"
+  when: pkgjson.stat.exists | default(false)

--- a/roles/run_webpack/tasks/main.yml
+++ b/roles/run_webpack/tasks/main.yml
@@ -1,34 +1,58 @@
-###
-# Run webpack to compile static assets (css and javascript).
-#
-# This role runs Webpack to compile and compress source javascript and styles
-# into css/js files. It depends on webpack and all its associated js dependencies
-# having been installed, usually through the 'build_npm' role.
-#
-# The role expects that appropriate staging/prod-specific tasks will be defined in
-# package.json and callable via `npm run build:qa` and `npm run build:prod`.
-# The default commands may be customized by configuring
-# `webpack_build_prod` and `webpack_build_qa`
-#
-###
 ---
 - name: Run webpack build tasks for static assets
   become: true
   become_user: "{{ django_user }}"
   block:
-    # NOTE: for historic reasons, the staging build is labeled as qa
-    # because that is how it is defined in the application npm package
-    - name: Run wepback in staging/QA mode
-      shell: "npm run {{ webpack_build_qa }}"
+    - name: run_webpack | Preflight package.json exists
+      ansible.builtin.stat:
+        path: "{{ npm_install_path }}/package.json"
+      register: pkg
+      changed_when: false
+
+    - name: run_webpack | Preflight webpack shim exists
+      ansible.builtin.stat:
+        path: "{{ npm_install_path }}/node_modules/.bin/webpack"
+      register: webpack_shim
+      changed_when: false
+
+    - name: run_webpack | Fail early if prerequisites missing
+      ansible.builtin.fail:
+        msg: >-
+          Missing webpack prerequisites in {{ npm_install_path }}.
+          package.json={{ pkg.stat.exists | default(false) }},
+          node_modules/.bin/webpack={{ webpack_shim.stat.exists | default(false) }}.
+          Ensure build_npm ran for this release and npm_install_path points at /srv/www/<app>/current.
+      when: not (pkg.stat.exists | default(false)) or not (webpack_shim.stat.exists | default(false))
+
+    - name: run_webpack | Run webpack in staging/QA mode
+      ansible.builtin.shell: |
+        set -euo pipefail
+        export PATH="{{ npm_install_path }}/node_modules/.bin:${PATH}"
+        npm run {{ webpack_build_qa }}
       args:
         chdir: "{{ npm_install_path }}"
         executable: /bin/bash
       when: runtime_env == "staging"
-    - name: Run webpack production build
-      shell: "npm run {{ webpack_build_prod }}"
+
+    - name: run_webpack | Run webpack production build
+      ansible.builtin.shell: |
+        set -euo pipefail
+        export PATH="{{ npm_install_path }}/node_modules/.bin:${PATH}"
+        npm run {{ webpack_build_prod }}
       args:
         chdir: "{{ npm_install_path }}"
         executable: /bin/bash
-      when: runtime_env == "production" or  runtime_env == "preproduction"
+      when: runtime_env in ["production", "preproduction"]
+
   rescue:
-    - include_tasks: roles/create_deployment/tasks/fail.yml
+    - name: run_webpack | Show webpack failure output
+      ansible.builtin.debug:
+        msg: |
+          stdout: {{ ansible_failed_result.stdout | default('') }}
+          stderr: {{ ansible_failed_result.stderr | default('') }}
+          rc: {{ ansible_failed_result.rc | default('') }}
+      failed_when: false
+
+    - name: run_webpack | Fail
+      ansible.builtin.fail:
+        msg: "run_webpack failed (npm/webpack build). See debug output above."


### PR DESCRIPTION
Geniza deployments use a /srv/www/geniza/current symlink to the active release. Our webpack step was running against a specific release directory that did not have node_modules installed, causing "webpack: not found" failures.

This change pins npm_install_path for Geniza to the stable /srv/www/geniza/current path so build_npm and run_webpack operate against the same tree. A preflight check was added to fail early with a clear message when package.json or the local webpack shim is missing.

Side effects: webpack/npm tasks now follow the current symlink, so if "current" changes during a run it will affect which release is built. This matches the existing deployment contract.

**Associated Issue(s):** resolves #336 

### Changes in this PR
_Include all key changes in this pull request_

- Set `npm_install_path` for Geniza to the stable `/srv/www/geniza/current` path so `build_npm` and `run_webpack` operate on the same tree.
- Add preflight checks in `run_webpack` to validate `package.json` and the local `node_modules/.bin/webpack` shim exist before running the build, with a clear failure message.

### Notes
_Include any additional notes that will help in the reviewing of this pull request_

- This addresses intermittent `webpack: not found` failures caused by running the webpack build in a release directory that did not have node_modules installed.
- Webpack/npm commands now intentionally follow the `current` symlink (Capistrano-style contract). If `current` changes mid-run, the build target will change accordingly.

### Reviewer Checklist
_Include **discrete** checks that should be done by the reviewer beyond looking through
code and/or file changes. Note that this check list will correspond to tasks within
the PR overview page._

- [x]  Deploy to Geniza test and confirm `run_webpack` succeeds (no `webpack: not found`).
- [x]  Confirm the `run_webpack` preflight correctly fails with a clear message if `node_modules` is missing (e.g., by running before build_npm or in an empty release dir).