### PR TITLE
Switch to load balanced server name for tigerdata NFS

### DIFF
--- a/inventory/group_vars/all/vars.yml
+++ b/inventory/group_vars/all/vars.yml
@@ -134,7 +134,7 @@ nfs_domain: "princeton.edu"
 ## tigerdata
 # NOTE: disabled by default; must opt in by host group; requires firewall access
 tigerdata_enabled: false
-tigerdata_nfs_server: "td-mf-cl2.princeton.edu"
+tigerdata_nfs_server: "tigerdata-nfs.princeton.edu"
 tigerdata_mount_port: 2049
 tigerdata_cdh_group: "cdh"
 tigerdata_cdh_gid: 30369


### PR DESCRIPTION
Updates shared inventory variables to use the load-balanced server name for TigerData NFS.

This change has already been propagated to existing VMs.