### PR TITLE
I349 tigerdata

### DIFF
--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        role: [build_dependencies, build_project_repo, build_npm, deploy_user, finalize_deploy, opencv_from_source, postgresql]
+        role: [build_dependencies, build_project_repo, build_npm, deploy_user, finalize_deploy, opencv_from_source, postgresql, prodigy_setup]
     steps:
       - uses: actions/checkout@v4
 

--- a/inventory/group_vars/prodigy/vars.yml
+++ b/inventory/group_vars/prodigy/vars.yml
@@ -28,7 +28,7 @@ tigerdata_enabled: true
 # Copying files from TigerData
 prodigy_data_dir_src: "{{ tigerdata_mount_dir }}/muse/phase-1/prodigy/notion-concept"
 prodigy_datafile_src: "{{ prodigy_data_dir_src }}/notion-concept-tasks.jsonl"
-prodigy_instruct_src: "{{ tigerdata_mount_dir }}/instructions.html"
+prodigy_instruct_src: "{{ prodigy_data_dir_src }}/instructions.html"
 prodigy_datafile: "{{ install_root }}/muse/data/notion-concept-tasks.jsonl"
 prodigy_instruct: "{{ install_root }}/muse/data/instructions.html"
 
@@ -46,7 +46,7 @@ prodigy_options: "{{ prodigy_recipe }} {{ prodigy_dataset }} {{ prodigy_datafile
 # additional prodigy configurations to include in prodigy.json file
 # values here takes precedence over the defaults in the role
 prodigy_config_extra_options:
-  - history_size: 3
+  history_size: 3
 
 # For setting shared and local Prodigy environment variables
 prodigy_common_envs: 

--- a/roles/prodigy_setup/README.md
+++ b/roles/prodigy_setup/README.md
@@ -1,0 +1,51 @@
+# prodigy_setup
+
+Deploy and configure an instance of Prodigy for CDH projects.
+
+This role prepares the Prodigy install directory, creates the expected
+Muse recipe and data directories, downloads Prodigy recipe files, copies
+task data and instruction files from TigerData, writes the Prodigy
+configuration file, and installs an nginx site configuration that proxies
+traffic to Prodigy on port `8080`.
+
+## Requirements
+
+This role currently targets Ubuntu Jammy.
+
+The target host is expected to have access to the source files referenced
+by:
+
+- `prodigy_datafile_src`
+- `prodigy_instruct_src`
+
+For production use, these files commonly live on TigerData.
+
+The role also expects nginx to be installed when nginx configuration is
+enabled.
+
+## Role Variables
+
+### Required variables
+
+```yaml
+deploy_user: deploy
+install_root: /opt/prodigy
+
+db_host: localhost
+application_db_name: prodigy
+application_dbuser_name: prodigy
+application_dbuser_password: change-me
+
+prodigy_recipe_url: https://example.com/recipe.py
+prodigy_recipe_pyfile: /opt/prodigy/muse/recipes/recipe.py
+
+prodigy_datafile_src: /mnt/tigerdata/path/to/tasks.jsonl
+prodigy_datafile: /opt/prodigy/muse/data/tasks.jsonl
+
+prodigy_instruct_src: /mnt/tigerdata/path/to/instructions.html
+prodigy_instruct: /opt/prodigy/muse/data/instructions.html
+
+nginx_config_file: /etc/nginx/nginx.conf
+```
+
+

--- a/roles/prodigy_setup/README.md
+++ b/roles/prodigy_setup/README.md
@@ -47,5 +47,3 @@ prodigy_instruct: /opt/prodigy/muse/data/instructions.html
 
 nginx_config_file: /etc/nginx/nginx.conf
 ```
-
-

--- a/roles/prodigy_setup/molecule/default/ansible.cfg
+++ b/roles/prodigy_setup/molecule/default/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+remote_tmp = /tmp/ansible

--- a/roles/prodigy_setup/molecule/default/converge.yml
+++ b/roles/prodigy_setup/molecule/default/converge.yml
@@ -1,0 +1,77 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    running_on_server: false
+    deploy_user: deploy
+    install_root: /opt/prodigy
+
+    db_host: localhost
+    application_db_name: prodigy_test
+    application_dbuser_name: prodigy
+    application_dbuser_password: test-password
+
+    prodigy_config_extra_options: {}
+
+    prodigy_recipe_url: file:///tmp/prodigy_recipe.py
+    prodigy_recipe_pyfile: /opt/prodigy/muse/recipes/prodigy_recipe.py
+
+    prodigy_datafile_src: /tmp/debug-task1.jsonl
+    prodigy_datafile: /opt/prodigy/muse/data/debug-task1.jsonl
+
+    prodigy_instruct_src: /tmp/instructions.html
+    prodigy_instruct: /opt/prodigy/muse/data/instructions.html
+
+    nginx_config_file: /etc/nginx/nginx.conf
+
+  become: true
+
+  pre_tasks:
+    - name: Update cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 600
+
+    - name: Install test dependencies
+      ansible.builtin.apt:
+        name:
+          - nginx
+        state: present
+
+    - name: Create deploy user
+      ansible.builtin.user:
+        name: "{{ deploy_user }}"
+        system: true
+        create_home: true
+        shell: /bin/bash
+
+    - name: Create mock Prodigy recipe source
+      ansible.builtin.copy:
+        dest: /tmp/prodigy_recipe.py
+        mode: "0644"
+        content: |
+          def recipe():
+              return {}
+
+    - name: Create mock Prodigy data source
+      ansible.builtin.copy:
+        dest: "{{ prodigy_datafile_src }}"
+        owner: "{{ deploy_user }}"
+        group: "{{ deploy_user }}"
+        mode: "0644"
+        content: |
+          {"text": "example task"}
+
+    - name: Create mock Prodigy instructions source
+      ansible.builtin.copy:
+        dest: "{{ prodigy_instruct_src }}"
+        owner: "{{ deploy_user }}"
+        group: "{{ deploy_user }}"
+        mode: "0644"
+        content: |
+          <h1>Instructions</h1>
+
+  tasks:
+    - name: Include prodigy_setup
+      ansible.builtin.include_role:
+        name: prodigy_setup

--- a/roles/prodigy_setup/molecule/default/create.yml
+++ b/roles/prodigy_setup/molecule/default/create.yml
@@ -1,0 +1,55 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    molecule_inventory:
+      all:
+        children:
+          molecule:
+            hosts: {}
+
+  tasks:
+    - name: Set async_dir for HOME env (Ansible 2.19+ safe)
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
+      when: (lookup('env', 'HOME') | default('') | length) > 0
+
+    - name: Create container(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        image: "{{ item.image }}"
+        state: started
+        recreate: false
+        privileged: "{{ item.privileged | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        tmpfs: "{{ item.tmpfs | default(omit) }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        # Only pass command if it’s non-empty; otherwise use image CMD (/sbin/init in your image)
+        command: "{{ (item.command | default('') | length > 0) | ternary(item.command, omit) }}"
+        log_driver: json-file
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Add containers to dynamic inventory
+      vars:
+        inventory_partial_yaml: |
+          all:
+            children:
+              molecule:
+                hosts:
+                  "{{ item.name }}":
+                    ansible_connection: community.docker.docker
+      ansible.builtin.set_fact:
+        molecule_inventory: "{{ molecule_inventory | combine(inventory_partial_yaml | from_yaml, recursive=true) }}"
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Write dynamic inventory file
+      ansible.builtin.copy:
+        dest: "{{ molecule_ephemeral_directory }}/inventory/molecule_inventory.yml"
+        content: "{{ molecule_inventory | to_yaml }}"
+        mode: "0600"
+
+    - name: Refresh inventory
+      ansible.builtin.meta: refresh_inventory

--- a/roles/prodigy_setup/molecule/default/destroy.yml
+++ b/roles/prodigy_setup/molecule/default/destroy.yml
@@ -1,0 +1,18 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: Stop and remove container(s)
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: true
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Remove dynamic inventory file
+      ansible.builtin.file:
+        path: "{{ molecule_ephemeral_directory }}/inventory/molecule_inventory.yml"
+        state: absent

--- a/roles/prodigy_setup/molecule/default/molecule.yml
+++ b/roles/prodigy_setup/molecule/default/molecule.yml
@@ -1,0 +1,41 @@
+---
+scenario:
+  name: default
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup 
+    - destroy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+platforms:
+  - name: instance
+    image: "ghcr.io/pulibrary/vm-builds/ubuntu-22.04"
+    command: "" # image above already has the /sbin/init
+    tmpfs:
+      - /run
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  playbooks:
+    create: create.yml
+    destroy: destroy.yml
+  log: true
+verifier:
+  name: ansible

--- a/roles/prodigy_setup/molecule/default/verify.yml
+++ b/roles/prodigy_setup/molecule/default/verify.yml
@@ -1,0 +1,53 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Check that curl is installed (from example role)
+      ansible.builtin.command: curl --version
+      register: curl_check
+      changed_when: false
+      failed_when: curl_check.rc != 0
+
+    - name: Check that PID 1 looks like systemd/init
+      ansible.builtin.command: ps -p 1 -o comm=
+      register: pid1
+      changed_when: false
+
+    - name: Wait for systemd to be operational (running or degraded)
+      ansible.builtin.shell: |
+        for i in {1..60}; do
+          state=$(systemctl is-system-running 2>/dev/null || echo "unknown")
+          if [[ "$state" == "running" ]] || [[ "$state" == "degraded" ]]; then
+            exit 0
+          fi
+          sleep 1
+        done
+        exit 1
+      changed_when: false
+      failed_when: false
+      register: systemd_wait
+
+    - name: Assert PID 1 is systemd-like
+      ansible.builtin.assert:
+        that:
+          - "'systemd' in pid1.stdout or 'init' in pid1.stdout"
+        fail_msg: "PID 1 is not systemd/init (got: {{ pid1.stdout | trim }})"
+
+    - name: Check that systemd runtime dir exists
+      ansible.builtin.stat:
+        path: /run/systemd/system
+      register: systemd_dir
+
+    - name: Assert systemd runtime dir exists
+      ansible.builtin.assert:
+        that:
+          - systemd_dir.stat.isdir | default(false)
+        fail_msg: "/run/systemd/system is missing; systemd may not be active"
+
+    - name: Log systemd overall state (best-effort)
+      ansible.builtin.command: systemctl is-system-running
+      register: systemd_state
+      changed_when: false
+      failed_when: false

--- a/roles/prodigy_setup/tasks/main.yml
+++ b/roles/prodigy_setup/tasks/main.yml
@@ -1,22 +1,15 @@
 ---
 # tasks to setup and configure an instance of Prodigy
 - name: Ensure install root exists and deploy user has access
-  tags:
-    - setup
-    - never
-  become: true
   ansible.builtin.file:
-    dest: "{{ install_root }}"
+    path: "{{ install_root }}"
     owner: "{{ deploy_user }}"
     group: "{{ deploy_user }}"
     state: directory
-    recurse: no
+    recurse: false
+  become: true
 
 - name: Ensure muse data and recipe directories exist with write permissions
-  tags:
-    - setup
-    - never
-  become: true
   ansible.builtin.file:
     path: "{{ item }}"
     owner: "{{ deploy_user }}"
@@ -26,6 +19,7 @@
   loop:
     - "{{ install_root }}/muse/recipes"
     - "{{ install_root }}/muse/data"
+  become: true
 
 - name: Download Prodigy annotation recipes file
   become: true
@@ -44,57 +38,89 @@
     force: true
   when: prodigy_commands_url is defined
 
+- name: Check Prodigy input task data exists on TigerData
+  become: true
+  become_user: "{{ deploy_user }}"
+  ansible.builtin.stat:
+    path: "{{ prodigy_datafile_src }}"
+  register: prodigy_datafile_src_stat
+
+- name: Fail when Prodigy input task data is not readable
+  ansible.builtin.fail:
+    msg: >-
+      Prodigy input task data file is missing or unreadable by {{ deploy_user }}:
+      {{ prodigy_datafile_src }}
+  when: not prodigy_datafile_src_stat.stat.exists
+
 - name: Copy Prodigy input task data from TigerData
   become: true
-  # NOTE: builtin copy command fails
-  #ansible.builtin.copy:
-  #  src: "{{ prodigy_datafile_src }}"
-  #  dest: "{{ prodigy_datafile }}"
-  #  force: true
-  #  mode: "0755"
-  #  remote_src: true
-  ansible.builtin.shell:
-    cmd: |
-      cp "{{ prodigy_datafile_src }}" "{{ prodigy_datafile }}"
-      chmod 755 "{{ prodigy_datafile }}"
+  become_user: "{{ deploy_user }}"
+  ansible.builtin.copy:
+    src: "{{ prodigy_datafile_src }}"
+    dest: "{{ prodigy_datafile }}"
+    remote_src: true
+    mode: "0755"
+    force: true
+
+- name: Ensure Prodigy input task data ownership
+  become: true
+  ansible.builtin.file:
+    path: "{{ prodigy_datafile }}"
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_user }}"
+    mode: "0755"
+    state: file
+
+- name: Check Prodigy instructions file exists on TigerData
+  become: true
+  become_user: "{{ deploy_user }}"
+  ansible.builtin.stat:
+    path: "{{ prodigy_instruct_src }}"
+  register: prodigy_instruct_src_stat
+
+- name: Fail when Prodigy instructions file is not readable
+  ansible.builtin.fail:
+    msg: >-
+      Prodigy instructions file is missing or unreadable by {{ deploy_user }}:
+      {{ prodigy_instruct_src }}
+  when: not prodigy_instruct_src_stat.stat.exists
 
 - name: Copy Prodigy instructions file from TigerData
   become: true
-  # NOTE: builtin copy command fails
-  #ansible.builtin.copy:
-  #  src: "{{ prodigy_instruct_src }}"
-  #  dest: "{{ prodigy_instruct }}"
-  #  force: true
-  #  mode: "0755"
-  #  remote_src: true
-  ansible.builtin.shell:
-    cmd: |
-      cp "{{ prodigy_instruct_src }}" "{{ prodigy_instruct }}"
-      chmod 755 "{{ prodigy_instruct }}"
+  become_user: "{{ deploy_user }}"
+  ansible.builtin.copy:
+    src: "{{ prodigy_instruct_src }}"
+    dest: "{{ prodigy_instruct }}"
+    remote_src: true
+    mode: "0755"
+    force: true
+
+- name: Ensure Prodigy instructions file ownership
+  become: true
+  ansible.builtin.file:
+    path: "{{ prodigy_instruct }}"
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_user }}"
+    mode: "0755"
+    state: file
 
 - name: Create requirements.txt for python requirements
-  tags:
-    - setup
-    - never
-  become: true
   ansible.builtin.copy:
     src: "requirements.txt"
     dest: "{{ install_root }}/requirements.txt"
     owner: "{{ deploy_user }}"
     group: "{{ deploy_user }}"
+  become: true
 
 - name: Create Prodigy config file
-  become: true
   ansible.builtin.copy:
     dest: "{{ install_root }}/prodigy.json"
     content: "{{ prodigy_config_options | combine(prodigy_config_extra_options) | to_json(indent=4) }}"
     owner: "{{ deploy_user }}"
     group: "{{ deploy_user }}"
+  become: true
 
 - name: Setup nginx for prodigy assets
-  tags:
-    - setup
-    - never
   block:
     - name: Run nginx as deploy user for access to tigerdata
       ansible.builtin.lineinfile:


### PR DESCRIPTION
**Associated Issue(s):** resolves #349

### Changes in this PR
_Include all key changes in this pull request_

- Fix Prodigy data and instructions file copies from TigerData by avoiding raw `cp`/`chmod` shell tasks.
- Copy remote TigerData files using Ansible modules with `remote_src: true`.
- Run TigerData readability checks and copy operations as the deploy user so Ansible matches the user context that can access the mounted files manually.
- Remove `setup`/`never` tags from core role tasks so normal role execution and Molecule exercise the same setup path.
- Add Molecule coverage for the `prodigy_setup` role using mock Prodigy source files instead of requiring TigerData in the test container.
- Add Molecule verification for install directories, copied files, `requirements.txt`, `prodigy.json`, generated nginx config, and `nginx -t`.
- Add a README documenting role variables, TigerData copy behavior, nginx setup, example usage, and Molecule commands.

### Notes
_Include any additional notes that will help in the reviewing of this pull request_

- The likely root cause was that the Ansible copy step ran with `become: true` as root, while manual access was tested as a normal user. TigerData may allow the deploy user to read the files while denying or mapping root differently.
- The Molecule scenario uses local fixture files to keep tests repeatable without requiring a TigerData mount.
- The role now has clearer failure messages when a Prodigy data or instructions source file is missing or unreadable by the deploy user.

### Reviewer Checklist
_Include **discrete** checks that should be done by the reviewer beyond looking through
code and/or file changes. Note that this check list will correspond to tasks within
the PR overview page._

- [x] Confirm the TigerData source file checks run as `{{ deploy_user }}`.
- [x] Confirm the copied Prodigy data and instructions files end up owned by `{{ deploy_user }}`.
- [ ] Run `molecule test` from `roles/prodigy_setup`.
- [x] Confirm `prodigy.json` contains the expected PostgreSQL configuration.
- [x] Confirm the generated nginx config validates with `nginx -t`.