### PR TITLE
[build_npm] update the base url for nodejs

### DIFF
--- a/roles/build_npm/defaults/main.yml
+++ b/roles/build_npm/defaults/main.yml
@@ -12,7 +12,7 @@ desired_nodejs_version: "22.4.0"
 nodejs_install_method: "prebuilt"
 
 # Internal mirror by default (fast + reliable + consistent)
-nodejs_release_base_url: "https://pulmirror.princeton.edu/mirror/node/dist"
+nodejs_release_base_url: "https://pulmirror.princeton.edu/mirror/nodejs"
 
 # Download resilience
 nodejs_download_timeout: 600


### PR DESCRIPTION
the pulmirror is now following upstream which brings the paths for nodejs to the root

**Associated Issue(s):** resolves #354 

### Changes in this PR
_Include all key changes in this pull request_

- https://pulmirror.princeton.edu/mirror/nodejs  (is the working base URI)
