### PR TITLE
Switch eScriptorium to Adroit and fix Celery worker concurrency

### DIFF
--- a/inventory/group_vars/htr/vars.yml
+++ b/inventory/group_vars/htr/vars.yml
@@ -140,11 +140,11 @@ supervisor_programs:
       killasgroup=true
       stopasgroup=true
 
-  # 2) celery worker
+  # 2) celery workers (split by queue to prevent concurrent jobs from hanging)
   # based on the command in the full local deploy
-  # celery -A escriptorium worker -l INFO
-  - name: "celery"
-    command: "{{ django_app_path }}/env/bin/celery -A escriptorium worker -l INFO"
+  # (docker compose starts multiple celery workers with different queues/priorities)
+  - name: "celery-main"
+    command: "{{ django_app_path }}/env/bin/celery -A escriptorium worker -Q default --concurrency 1 -l INFO"
     state: present
     configuration: |
       directory={{ django_app_path }}
@@ -154,8 +154,59 @@ supervisor_programs:
       startretries=1
       startsecs=1
       redirect_stderr=true
-      stderr_logfile=/var/log/supervisor/celery-err.log
-      stdout_logfile=/var/log/supervisor/celery-out.log
+      stderr_logfile=/var/log/supervisor/celery-main-err.log
+      stdout_logfile=/var/log/supervisor/celery-main-out.log
+      user={{ deploy_user }}
+      killasgroup=true
+      stopasgroup=true
+
+  - name: "celery-gpu"
+    command: "{{ django_app_path }}/env/bin/celery -A escriptorium worker -Q gpu --concurrency 8 -l INFO"
+    state: present
+    configuration: |
+      directory={{ django_app_path }}
+      environment=DJANGO_SETTINGS_MODULE="escriptorium.local_settings"
+      autostart=true
+      autorestart=true
+      startretries=1
+      startsecs=1
+      redirect_stderr=true
+      stderr_logfile=/var/log/supervisor/celery-gpu-err.log
+      stdout_logfile=/var/log/supervisor/celery-gpu-out.log
+      user={{ deploy_user }}
+      killasgroup=true
+      stopasgroup=true
+
+  - name: "celery-live"
+    command: "{{ django_app_path }}/env/bin/celery -A escriptorium worker -Q live --concurrency 8 -l INFO"
+    state: present
+    configuration: |
+      directory={{ django_app_path }}
+      environment=DJANGO_SETTINGS_MODULE="escriptorium.local_settings"
+      autostart=true
+      autorestart=true
+      startretries=1
+      startsecs=1
+      redirect_stderr=true
+      stderr_logfile=/var/log/supervisor/celery-live-err.log
+      stdout_logfile=/var/log/supervisor/celery-live-out.log
+      user={{ deploy_user }}
+      killasgroup=true
+      stopasgroup=true
+
+  - name: "celery-low-priority"
+    command: "{{ django_app_path }}/env/bin/celery -A escriptorium worker -Q low-priority --concurrency 7 -l INFO"
+    state: present
+    configuration: |
+      directory={{ django_app_path }}
+      environment=DJANGO_SETTINGS_MODULE="escriptorium.local_settings"
+      autostart=true
+      autorestart=true
+      startretries=1
+      startsecs=1
+      redirect_stderr=true
+      stderr_logfile=/var/log/supervisor/celery-low-priority-err.log
+      stdout_logfile=/var/log/supervisor/celery-low-priority-out.log
       user={{ deploy_user }}
       killasgroup=true
       stopasgroup=true

--- a/inventory/group_vars/htr/vars.yml
+++ b/inventory/group_vars/htr/vars.yml
@@ -36,8 +36,12 @@ python_version: "3.11"
 # nodejs version
 node_version: "18"
 # install local customizations as an extra package
+# Note: the standard `-e ref=GITREF` override controls the eScriptorium gitref only,
+# not the htr2hpc package. To deploy a specific htr2hpc branch or tag, use:
+#   -e htr2hpc_gitref=adroit
+htr2hpc_gitref: main
 python_extra_packages:
-  - git+https://github.com/Princeton-CDH/htr2hpc.git@adroit#egg=htr2hpc
+  - git+https://github.com/Princeton-CDH/htr2hpc.git@{{ htr2hpc_gitref }}#egg=htr2hpc
 
 # pul deploy user
 deploy_user: "conan"

--- a/inventory/group_vars/htr/vars.yml
+++ b/inventory/group_vars/htr/vars.yml
@@ -39,7 +39,7 @@ node_version: "18"
 # Note: the standard `-e ref=GITREF` override controls the eScriptorium gitref only,
 # not the htr2hpc package. To deploy a specific htr2hpc branch or tag, use:
 #   -e htr2hpc_gitref=adroit
-htr2hpc_gitref: main
+htr2hpc_gitref: develop
 python_extra_packages:
   - git+https://github.com/Princeton-CDH/htr2hpc.git@{{ htr2hpc_gitref }}#egg=htr2hpc
 

--- a/inventory/group_vars/htr/vars.yml
+++ b/inventory/group_vars/htr/vars.yml
@@ -37,7 +37,7 @@ python_version: "3.11"
 node_version: "18"
 # install local customizations as an extra package
 python_extra_packages:
-  - git+https://github.com/Princeton-CDH/htr2hpc.git@develop#egg=htr2hpc
+  - git+https://github.com/Princeton-CDH/htr2hpc.git@adroit#egg=htr2hpc
 
 # pul deploy user
 deploy_user: "conan"

--- a/roles/django/templates/escriptorium_settings.py.j2
+++ b/roles/django/templates/escriptorium_settings.py.j2
@@ -41,6 +41,22 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 # template and stylesheet are present.
 SHOW_TEST_WARNING = {{ django_test_warning }}
 
+# Celery task routing — directs each task type to the appropriate worker queue
+{% block celery_task_routes %}
+CELERY_TASK_ROUTES = {
+    'core.tasks.recalculate_masks': {'queue': 'live'},
+    'core.tasks.generate_part_thumbnails': {'queue': 'low-priority'},
+    'core.tasks.train': {'queue': 'gpu'},
+    'core.tasks.segtrain': {'queue': 'gpu'},
+    'core.tasks.align': {'queue': 'jvm'},
+    'imports.tasks.*': {'queue': 'low-priority'},
+    'users.tasks.async_email': {'queue': 'low-priority'},
+    'htr2hpc.tasks.train': {'queue': 'gpu'},
+    'htr2hpc.tasks.segtrain': {'queue': 'gpu'},
+    'htr2hpc.tasks.hpc_user_setup': {'queue': 'gpu'},
+}
+{% endblock %}
+
 {% if media_root is defined %}
 # Configure media root path
 MEDIA_ROOT = '{{ media_root }}'
@@ -159,7 +175,7 @@ SOLR_CONNECTIONS = {
 # Extra app-specific configuration
 {% block extra_config %}
 # custom config for htr2hpc
-HPC_HOSTNAME = "della.princeton.edu"
+HPC_HOSTNAME = "adroit.princeton.edu"
 # copied in place by escriptorium_setup role
 HPC_SSH_KEYFILE = "/home/{{ deploy_user }}/.ssh/htr2hpc_id_ed25519"
 

--- a/roles/escriptorium_setup/handlers/main.yml
+++ b/roles/escriptorium_setup/handlers/main.yml
@@ -2,7 +2,12 @@
 # handlers file for escriptorium
 - name: Restart celery
   become: true
-  ansible.builtin.command: "sudo supervisorctl restart celery"
+  ansible.builtin.command: "sudo supervisorctl restart {{ item }}"
+  loop:
+    - celery-main
+    - celery-gpu
+    - celery-live
+    - celery-low-priority
 - name: Restart django_channels
   become: true
   ansible.builtin.command: "sudo supervisorctl restart django_channels"


### PR DESCRIPTION
**Associated Issue(s):** [#81](https://github.com/Princeton-CDH/htr2hpc/issues/81) [#82](https://github.com/Princeton-CDH/htr2hpc/issues/82)

### Changes in this PR

- Switch htr2hpc install to `adroit` branch so training jobs submit to Adroit instead of Della (Della folder structure changed and is no longer compatible)
- Split single Celery worker into four per-queue workers (`celery-main`, `celery-gpu`, `celery-live`, `celery-low-priority`) to fix concurrent recognition jobs hanging or queuing indefinitely
- Update `HPC_HOSTNAME` to `adroit.princeton.edu` in the settings template
- Add `CELERY_TASK_ROUTES` to route tasks to the correct Celery queues

### Notes

- These changes are based on fixes Christine made during beta testing (cmroughan/cdh-ansible commits c4d0edf, 4e14659, 69ff4a8) that were never merged into the main repo
- The Celery worker split is the key fix for the production issue where multiple simultaneous segmentation/transcription jobs hang or queue indefinitely
- Adroit also requires a Duo exemption — that needs to be requested separately

### Reviewer Checklist
