### PR TITLE
Set htr2hpc_gitref default to main; override to develop for staging

### DIFF
--- a/inventory/group_vars/htr/vars.yml
+++ b/inventory/group_vars/htr/vars.yml
@@ -39,7 +39,7 @@ node_version: "18"
 # Note: the standard `-e ref=GITREF` override controls the eScriptorium gitref only,
 # not the htr2hpc package. To deploy a specific htr2hpc branch or tag, use:
 #   -e htr2hpc_gitref=adroit
-htr2hpc_gitref: develop
+htr2hpc_gitref: main
 python_extra_packages:
   - git+https://github.com/Princeton-CDH/htr2hpc.git@{{ htr2hpc_gitref }}#egg=htr2hpc
 

--- a/inventory/group_vars/htr_staging/vars.yml
+++ b/inventory/group_vars/htr_staging/vars.yml
@@ -12,6 +12,9 @@ passenger_server_name: test-htr.princeton.edu
 application_db_name: "cdh_test_htr"
 application_dbuser_name: "cdh_test_htr"
 
+# staging deploys htr2hpc from develop; production uses main (set in group_vars/htr)
+htr2hpc_gitref: develop
+
 # observability
 beyla_enabled: true
 beyla_service_name: htr


### PR DESCRIPTION
**Associated Issue(s):** follow-up to #357

### Changes in this PR

- Set `htr2hpc_gitref` default to `main` in `group_vars/htr/vars.yml`
- Override to `develop` for staging in `group_vars/htr_staging/vars.yml`