### PR TITLE
Remove stale celery supervisor program left over from PR #357

### DIFF
--- a/inventory/group_vars/htr/vars.yml
+++ b/inventory/group_vars/htr/vars.yml
@@ -147,6 +147,11 @@ supervisor_programs:
   # 2) celery workers (split by queue to prevent concurrent jobs from hanging)
   # based on the command in the full local deploy
   # (docker compose starts multiple celery workers with different queues/priorities)
+
+  # Remove the old single celery worker (replaced by per-queue workers below)
+  - name: "celery"
+    state: absent
+
   - name: "celery-main"
     command: "{{ django_app_path }}/env/bin/celery -A escriptorium worker -Q default --concurrency 1 -l INFO"
     state: present

--- a/playbooks/escriptorium.yml
+++ b/playbooks/escriptorium.yml
@@ -31,6 +31,8 @@
     - name: Restart supervisor apps to load any python/django configuration changes
       ansible.builtin.command: "sudo supervisorctl restart {{ item.name }}"
       loop: "{{ supervisor_programs }}"
+      # skip absent programs because they have already been removed and cannot be restarted
+      when: item.state | default('present') != 'absent'
     - name: Notify handler to restart nginx
       ansible.builtin.meta: noop
       notify:


### PR DESCRIPTION
**Associated Issue(s):** resolves Princeton-CDH/htr2hpc#81

### Changes in this PR
- Add `state: absent` for the old `celery` supervisor program that was left over from PR #357
- Add `when: item.state | default('present') != 'absent'` condition to the `supervisorctl restart` task in `escriptorium.yml` to avoid attempting to restart removed programs

### Notes
- Background: PR #357 renamed the single `celery` worker to `celery-main` and added 3 per-queue workers, but never explicitly removed the old `celery` entry. Our `supervisor` role only removes configs for programs listed with `state: absent`. Since `celery` was just dropped from the list, its config file persisted on the server and caused recognition jobs to run concurrently.
- Christine's [original commit](https://github.com/cmroughan/ChR-old-cdh-ansible/commit/c4d0edfdf325fcf3b7d40f496fc5ee552f730b65) actually included a commented-out `state: absent` block for the old `celery` worker. Her staging environment was likely a fresh deploy with no prior `celery` config on disk, so the stale worker was never an issue. Our environment was upgraded from an existing deployment, so the config persisted and the old worker kept running alongside the new per-queue workers.

### Checklist for myself
- [x] Deploy to **production**
- [x] Verify only the expected workers appear in `supervisorctl status`: `django_channels`, `celery-main`, `celery-gpu`, `celery-live`, `celery-low-priority`
- [x] Confirm `celery` is no longer listed

### Reviewer Checklist
- [x] Review the code change