### PR TITLE
Fix ineffective nginx restart for htr2hpc

### DIFF
--- a/playbooks/escriptorium.yml
+++ b/playbooks/escriptorium.yml
@@ -33,10 +33,10 @@
       loop: "{{ supervisor_programs }}"
       # skip absent programs because they have already been removed and cannot be restarted
       when: item.state | default('present') != 'absent'
-    - name: Notify handler to restart nginx
-      ansible.builtin.meta: noop
-      notify:
-        - Restart nginx
+    - name: Restart nginx after escriptorium patches are applied
+      ansible.builtin.service:
+        name: nginx
+        state: restarted
   environment:
     # escriptorium local settings REPLACES default settings, must be specified
     # via env var for django manage commands to pick up


### PR DESCRIPTION
**Associated Issue(s):** resolves #princeton-cdh/htr2hpc#102

### Changes in this PR
- Replace ineffective `meta: noop` + `notify` with an explicit service restart task at the end of `escriptorium.yml`
- The `meta` tasks do not support `notify`, so the `nginx` handler was silently never triggered after escriptorium patches were applied.

### Notes
- This bug was already exist and non-functional before the PR #364 fix.
- Verified the current fix is working when deployed Chrsitine's `feature/kraken6` and confirmed nginx restarted at the end of the playbook without requiring a manual restart.

### Reviewer Checklist
- [x] Review the code
