### PR TITLE
Add deployment docs for htr2hpc

### DIFF
--- a/docs/applications/escriptorium.md
+++ b/docs/applications/escriptorium.md
@@ -24,7 +24,7 @@ ansible-playbook playbooks/escriptorium.yml -t reinstall-htr2hpc
 ```
 
 This tag uninstalls the current htr2hpc package and reinstalls the version
-specified by `htr2hpc_gitref` (defaults to `main`). To deploy a specific
+specified by `htr2hpc_gitref` (defaults to `main` for production environment). To deploy a specific
 branch or tag, override the variable:
 
 ```sh

--- a/docs/applications/escriptorium.md
+++ b/docs/applications/escriptorium.md
@@ -17,7 +17,7 @@
 
 The full deploy playbook does **not** reinstall the htr2hpc Python package by
 default — it only runs when eScriptorium itself is being redeployed. To update
-htr2hpc to a new release, use the `reinstall-htr2hpc` tag:
+htr2hpc to a new branch or release or to ensure changes on an existing branch are installed, use the `reinstall-htr2hpc` tag:
 
 ```sh
 ansible-playbook playbooks/escriptorium.yml -t reinstall-htr2hpc

--- a/docs/applications/escriptorium.md
+++ b/docs/applications/escriptorium.md
@@ -31,6 +31,6 @@ branch or tag, override the variable:
 ansible-playbook playbooks/escriptorium.yml -t reinstall-htr2hpc -e htr2hpc_gitref=0.6.0
 ```
 
-After reinstalling, the tag restarts nginx, Celery, and Django Channels to
+After reinstalling, the task restarts nginx, Celery, and Django Channels to
 pick up the new code. Use this tag whenever a new htr2hpc release has been
 published and needs to be deployed — it is not needed for other playbook changes.

--- a/docs/applications/escriptorium.md
+++ b/docs/applications/escriptorium.md
@@ -1,0 +1,36 @@
+# eScriptorium / htr2hpc
+
+[eScriptorium](https://gitlab.com/scripta/escriptorium) is an open-source handwritten text recognition (HTR) application. CDH runs a customized instance that integrates with Princeton's HPC clusters via the [htr2hpc](https://github.com/Princeton-CDH/htr2hpc) package.
+
+- eScriptorium software: https://gitlab.com/scripta/escriptorium
+- htr2hpc software: https://github.com/Princeton-CDH/htr2hpc
+
+## Related playbooks
+
+- The eScriptorium application can be deployed to staging or production with
+  the `escriptorium` playbook. Staging is the default; pass `-e runtime_env=production`
+  for production.
+- To update only the htr2hpc package without a full redeploy, use the
+  `reinstall-htr2hpc` tag (see below).
+
+## Updating htr2hpc
+
+The full deploy playbook does **not** reinstall the htr2hpc Python package by
+default — it only runs when eScriptorium itself is being redeployed. To update
+htr2hpc to a new release, use the `reinstall-htr2hpc` tag:
+
+```sh
+ansible-playbook playbooks/escriptorium.yml -t reinstall-htr2hpc
+```
+
+This tag uninstalls the current htr2hpc package and reinstalls the version
+specified by `htr2hpc_gitref` (defaults to `main`). To deploy a specific
+branch or tag, override the variable:
+
+```sh
+ansible-playbook playbooks/escriptorium.yml -t reinstall-htr2hpc -e htr2hpc_gitref=0.6.0
+```
+
+After reinstalling, the tag restarts nginx, Celery, and Django Channels to
+pick up the new code. Use this tag whenever a new htr2hpc release has been
+published and needs to be deployed — it is not needed for other playbook changes.


### PR DESCRIPTION
**Associated Issue(s):** resolves Princeton-CDH/htr2hpc#103

### Changes in this PR

- Add `docs/applications/escriptorium.md`
- Document htr2hpc deployment, including application architecture, how to run the playbook, and how to use the `reinstall-htr2hpc` tag to update the htr2hpc package independently of a full redeploy

### Reviewer's Checklist
- [ ] Check if the doc is sufficient