### PR TITLE
Fix YAML syntax for otel_collector and beyla staging-only roles

### DIFF
--- a/playbooks/escriptorium.yml
+++ b/playbooks/escriptorium.yml
@@ -7,10 +7,10 @@
   remote_user: pulsys
   become: true
   roles:
-    - pulibrary.princeton_ansible.otel_collector
-  when: runtime_env == "staging"
-    - pulibrary.princeton_ansible.beyla
-  when: runtime_env == "staging"
+    - role: pulibrary.princeton_ansible.otel_collector
+      when: runtime_env == "staging"
+    - role: pulibrary.princeton_ansible.beyla
+      when: runtime_env == "staging"
     - deploy_user
     - build_dependencies
     - build_project_repo


### PR DESCRIPTION
**Associated Issue(s):** resolves Princeton-CDH/cdh-ansible#372

### Changes in this PR
- Fix YAML syntax error in `escriptorium.yml` where `when` conditions for `otel_collector` and `beyla` roles were placed at the wrong indentation level
- Use the role dict form so `when` is properly nested under each role entry

### Notes
- This bug was introduced in commit `44a9998` (pushed directly to main), which repeated the same mistake from PR #369 that had already been reverted once.
- The misplaced `when` caused Ansible to fail to parse the playbook entirely.

### Reviewer Checklist
- [ ] Review the code