### PR TITLE
Fix activate alias in conan bash profile

### DIFF
--- a/roles/deploy_user/templates/bash_profile.j2
+++ b/roles/deploy_user/templates/bash_profile.j2
@@ -4,7 +4,7 @@
 {% if single_app and install_root is defined %}
 # alias to change directory to current deployed version
 # and activate python virtualenv
-alias activate="[ -d "{{ current_deploy }}" ] && cd {{ current_deploy }} && source {{ python_venv_path_prefix }}env/bin/activate"
+alias activate="[ -d "{{ install_root }}/current" ] && cd {{ install_root }}/current && source {{ python_venv_path_prefix }}env/bin/activate"
 
 # activate on login by default for interactive sessions only
 if [[ $- == *i* ]]


### PR DESCRIPTION
**Associated Issue(s):** resolves Princeton-CDH/htr2hpc#106

### Changes in this PR
- `bash_profile.j2`: use `{{ install_root }}/current` instead of `current_deploy` in the `activate` alias

### Reviewer Checklist
- [ ] Log in as `conan` on both VMs and verify the virtualenv is activated automatically