### PR TITLE
Revert escriptorium deploy to single fixed directory

### DIFF
--- a/inventory/group_vars/htr/vars.yml
+++ b/inventory/group_vars/htr/vars.yml
@@ -20,6 +20,9 @@ gitref: dev-0.14.2
 repo: scripta/escriptorium
 # name of django application (used by build_project_repo)
 python_app: "escriptorium"
+# set version to match gitref since eScriptorium has no __version__ attribute;
+# build_project_repo will skip auto-detection when python_app_version is pre-set
+python_app_version: "{{ gitref }}"
 django_app: "{{ python_app }}"
 # django app & python requirements are nested under the app folder
 django_app_path: "{{ deploy }}/app"

--- a/inventory/group_vars/htr/vars.yml
+++ b/inventory/group_vars/htr/vars.yml
@@ -20,9 +20,6 @@ gitref: dev-0.14.2
 repo: scripta/escriptorium
 # name of django application (used by build_project_repo)
 python_app: "escriptorium"
-# set version to match gitref since eScriptorium has no __version__ attribute;
-# build_project_repo will skip auto-detection when python_app_version is pre-set
-python_app_version: "{{ gitref }}"
 django_app: "{{ python_app }}"
 # django app & python requirements are nested under the app folder
 django_app_path: "{{ deploy }}/app"
@@ -74,8 +71,9 @@ deploy_env_vars:
   DJANGO_SETTINGS_MODULE: escriptorium.local_settings
   VERSION_DATE: "{{ gitref }}"  # deployed version, for display on home page
 
-deploy: "{{ install_root }}/{{ python_app_version }}-{{ short_hash }}"
-current_deploy: "{{ install_root }}/{{ python_app_version }}-{{ short_hash }}"
+# single deploy path - no versioning, no nesting
+deploy: "{{ install_root }}"
+current_deploy: "{{ install_root }}"
 python_app_path: "{{ deploy }}"
 python_venv_prompt: "escriptorium"
 # default requirements file is directly under the app; escriptorium has it nested


### PR DESCRIPTION
**Associated Issue(s):** resolves Princeton-CDH/htr2hpc#105

### Changes in this PR
- `inventory/group_vars/htr/vars.yml`: revert `deploy` and `current_deploy` to `{{ install_root }}` (single fixed directory); remove `python_app_version` override

### Reviewer Checklist
- [x] Log in as `conan` on both VMs and verify the virtualenv is activated automatically