### PR TITLE
Make HTR Python version release-aware

### DIFF
--- a/inventory/group_vars/htr/vars.yml
+++ b/inventory/group_vars/htr/vars.yml
@@ -32,7 +32,10 @@ python_venv_path_prefix: "app/"
 # symlink for web application
 symlink: "{{ app_name }}"
 # use python 3.11; kraken doesn't yet support 3.12
-python_version: "3.11"
+python_version_by_distribution_release:
+  jammy: "3.11"
+  noble: "3.12"
+python_version: "{{ python_version_by_distribution_release[ansible_distribution_release | lower] }}"
 # nodejs version
 node_version: "18"
 # install local customizations as an extra package

--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -21,6 +21,14 @@
         uid: "{{ deploy_user_uid }}"
         group: "{{ deploy_user }}"   # primary group
 
+    - name: Deploy_user - ensure deploy user home directory ownership
+      ansible.builtin.file:
+        path: "/home/{{ deploy_user }}"
+        state: directory
+        owner: "{{ deploy_user }}"
+        group: "{{ deploy_user }}"
+        mode: "0755"
+
     - name: Deploy_user - create bash profile
       ansible.builtin.template:
         src: "bash_profile.j2"

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -12,7 +12,7 @@ application_dbuser_password: changethis
 application_dbuser_role_attr_flags: ""
 # apt settings
 postgres_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
-postgres_apt_repository: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main {{ postgres_version }}'
+postgres_apt_repository_url: "https://apt.postgresql.org/pub/repos/apt"
 # task settings
 deploy_user: conan
 deploy_user_venv: "/home/{{ deploy_user }}/venv"
@@ -20,3 +20,4 @@ db_backup_path: "/home/{{ deploy_user }}/last_{{ application_db_name }}.sql"
 # feature flags
 postgres_setup_enabled: true
 postgres_backup_enabled: true
+

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -2,11 +2,47 @@
 - name: Setup Postgres Client and Configuration
   when: postgres_setup_enabled | bool
   block:
-    - name: Make sure CA certificates are available
+    - name: Make sure CA certificates and curl are available
       become: true
       ansible.builtin.apt:
-        pkg: ca-certificates
+        name:
+          - ca-certificates
+          - curl
         state: present
+        update_cache: true
+
+    - name: Ensure PostgreSQL apt key directory exists
+      become: true
+      ansible.builtin.file:
+        path: /usr/share/postgresql-common/pgdg
+        state: directory
+        mode: "0755"
+
+    - name: Install PostgreSQL apt repository key
+      become: true
+      ansible.builtin.get_url:
+        url: "{{ postgres_apt_key_url }}"
+        dest: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+        mode: "0644"
+
+    - name: Configure PostgreSQL apt repository
+      become: true
+      ansible.builtin.copy:
+        dest: /etc/apt/sources.list.d/pgdg.sources
+        mode: "0644"
+        content: |
+          Types: deb
+          URIs: https://apt.postgresql.org/pub/repos/apt
+          Suites: {{ ansible_distribution_release }}-pgdg
+          Components: main
+          Signed-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+      register: postgres_apt_repo
+
+    - name: Update apt cache after adding PostgreSQL repository
+      become: true
+      ansible.builtin.apt:
+        update_cache: true
+      when: postgres_apt_repo.changed
 
     - name: Install postgres client libraries
       become: true
@@ -19,13 +55,33 @@
         state: present
         update_cache: true
 
+    - name: set fqdn for use in pg_hba
+      ansible.builtin.set_fact:
+        "pg_hba_fqdn={{ ansible_facts['fqdn'] }}"
+
     - name: Ensure access to postgres server
       become: true
       ansible.builtin.lineinfile:
         path: "/etc/postgresql/{{ postgres_version }}/main/pg_hba.conf"
-        line: "host    all             all             {{ ansible_default_ipv4.address }}/32       md5"
+        line: "host    all             all             {{ pg_hba_fqdn }}       md5"
       delegate_to: "{{ postgres_host }}"
       notify: Reload remote postgres
+
+- name: PostgreSQL - set client address for pg_hba
+  ansible.builtin.set_fact:
+    pg_hba_client_address: "{{ ansible_default_ipv4.address }}/32"
+
+- name: PostgreSQL - ensure app host can access postgres server
+  become: true
+  ansible.builtin.lineinfile:
+    path: "/etc/postgresql/{{ postgres_version }}/main/pg_hba.conf"
+    line: "host    all             all             {{ pg_hba_client_address }}       md5"
+    state: present
+  delegate_to: "{{ postgres_host }}"
+  notify: Reload remote postgres
+
+- name: PostgreSQL - reload postgres before creating database resources
+  ansible.builtin.meta: flush_handlers
 
 - name: Create postgres user
   ansible.builtin.import_tasks: create_user.yml
@@ -38,3 +94,4 @@
 - name: Backup postgres database
   ansible.builtin.import_tasks: backup_db.yml
   when: postgres_backup_enabled | bool
+

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -11,9 +11,9 @@
   ansible.builtin.import_tasks: nfs.yml
   when: nfs_enabled
 
-  #- name: Setup - configure TigerData NFS mount point
-  # ansible.builtin.import_tasks: tigerdata_nfs.yml
-  # when: tigerdata_enabled
+- name: Setup - configure TigerData NFS mount point
+  ansible.builtin.import_tasks: tigerdata_nfs.yml
+  when: tigerdata_enabled
 
 - name: Setup - install and configure rclone
   ansible.builtin.import_tasks: rclone.yml

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -11,9 +11,9 @@
   ansible.builtin.import_tasks: nfs.yml
   when: nfs_enabled
 
-- name: Setup - configure TigerData NFS mount point
-  ansible.builtin.import_tasks: tigerdata_nfs.yml
-  when: tigerdata_enabled
+  #- name: Setup - configure TigerData NFS mount point
+  # ansible.builtin.import_tasks: tigerdata_nfs.yml
+  # when: tigerdata_enabled
 
 - name: Setup - install and configure rclone
   ansible.builtin.import_tasks: rclone.yml

--- a/roles/supervisor/tasks/main.yml
+++ b/roles/supervisor/tasks/main.yml
@@ -1,10 +1,40 @@
 ---
 # roles/supervisor
-- name: Supervisor - Ensure Supervisor is installed via pip.
+
+- name: Supervisor - ensure Python venv dependencies are installed.
+  ansible.builtin.apt:
+    name:
+      - python3-pip
+      - python3-venv
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  become: true
+
+- name: Supervisor - ensure Supervisor is installed in a virtualenv.
   ansible.builtin.pip:
     name: supervisor
     state: present
     version: "{{ supervisor_version | default(omit) }}"
+    virtualenv: "{{ supervisor_venv_path }}"
+    virtualenv_command: "{{ ansible_python_interpreter | default('/usr/bin/python3') }} -m venv"
+  become: true
+
+- name: Supervisor - ensure supervisord command is available.
+  ansible.builtin.file:
+    src: "{{ supervisor_venv_path }}/bin/supervisord"
+    dest: "{{ supervisor_bin_path }}"
+    state: link
+    force: true
+  become: true
+
+- name: Supervisor - ensure supervisorctl command is available.
+  ansible.builtin.file:
+    src: "{{ supervisor_venv_path }}/bin/supervisorctl"
+    dest: "{{ supervisorctl_bin_path }}"
+    state: link
+    force: true
+  become: true
 
 - name: Supervisor - ensure log dir exists.
   ansible.builtin.file:
@@ -52,16 +82,20 @@
   when: item.state | default('present') == 'absent'
   notify: restart supervisor
 
+- name: Supervisor - ensure started and enabled.
+  ansible.builtin.service:
+    name: supervisord
+    state: "{{ 'started' if supervisor_started else 'stopped' }}"
+    enabled: "{{ supervisor_enabled }}"
+
 - name: Supervisor - update to read new program configs
   community.general.supervisorctl:
     name: all
     state: present
     username: "{{ supervisor_user }}"
     password: "{{ supervisor_password }}"
-  when: supervisor_programs | length > 0
+    supervisorctl_path: "{{ supervisorctl_bin_path }}"
+  when:
+    - supervisor_started
+    - supervisor_programs | length > 0
 
-- name: Supervisor - ensure started and enabled.
-  ansible.builtin.service:
-    name: supervisord
-    state: "{{ 'started' if supervisor_started else 'stopped' }}"
-    enabled: "{{ supervisor_enabled }}"

--- a/roles/supervisor/vars/main.yml
+++ b/roles/supervisor/vars/main.yml
@@ -2,5 +2,6 @@
 ---
 # vars file for roles/supervisor
 #
+supervisor_venv_path: /opt/supervisor
 supervisor_bin_path: /usr/local/bin/supervisord
 supervisorctl_bin_path: /usr/local/bin/supervisorctl


### PR DESCRIPTION
**Associated Issue(s):** resolves #382 


### Changes in this PR
_Include all key changes in this pull request_

- Makes the HTR python_version release-aware by Ubuntu distribution release.
- Keeps Ubuntu 22.04 Jammy HTR hosts on Python 3.11.
- Uses Python 3.12 for Ubuntu 24.04 Noble HTR hosts.
- Fixes the Noble provisioning failure where libpython3.11-dev is unavailable.

### Notes
_Include any additional notes that will help in the reviewing of this pull request_

This addresses the failure seen on cdh-test-htr1.lib.princeton.edu.
The build_dependencies role continues to use the existing dependency template:
libpython{{ python_version }}-dev.
This change is scoped to HTR inventory variables and should not affect other roles or playbooks.


### Reviewer Checklist
_Include **discrete** checks that should be done by the reviewer beyond looking through

- [ ] Confirm Jammy HTR hosts still resolve python_version to 3.11.
- [ ] Confirm Noble HTR hosts resolve python_version to 3.12. 
- [ ] Confirm app_dependencies renders libpython3.12-dev on cdh-test-htr1.lib.princeton.edu.
- [ ] Run the HTR setup against cdh-test-htr1.lib.princeton.edu and confirm build_dependencies completes successfully.