### PR TITLE
HTR on jammy

### DIFF
--- a/roles/passenger/tasks/main.yml
+++ b/roles/passenger/tasks/main.yml
@@ -83,6 +83,17 @@
         filename: passenger
         update_cache: false
 
+    - name: Phusion | Prefer Phusion Passenger packages
+      ansible.builtin.copy:
+        dest: /etc/apt/preferences.d/phusion-passenger
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          Package: passenger libnginx-mod-http-passenger
+          Pin: origin "oss-binaries.phusionpassenger.com"
+          Pin-Priority: 1001
+
     - name: Passenger | Clean apt cache
       ansible.builtin.command: apt-get clean
       changed_when: false
@@ -110,13 +121,24 @@
       when: cache_update.rc != 0
 
     # Nginx and passenger installation.
-    - name: Install Nginx and Passenger.
+    - name: Install Nginx.
       tags:
         - setup
         - never
       become: true
       ansible.builtin.apt:
-        name: "{{ nginx_passenger_packages }}"
+        name: nginx-extras
+        state: present
+
+    - name: Install Passenger and Nginx Passenger module from Phusion.
+      tags:
+        - setup
+        - never
+      become: true
+      ansible.builtin.apt:
+        name:
+          - passenger
+          - libnginx-mod-http-passenger
         state: present
 
     # Nginx and passenger configuration.

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -44,16 +44,26 @@
         update_cache: true
       when: postgres_apt_repo.changed
 
-    - name: Install postgres client libraries
+    - name: Install Python postgres support packages
+      become: true
+      ansible.builtin.apt:
+       name:
+         - python3-dev
+         - python3-psycopg2
+       state: present
+       update_cache: true
+       cache_valid_time: 3600
+
+    - name: Install PostgreSQL client libraries from PGDG
       become: true
       ansible.builtin.apt:
         name:
+          - libpq5
           - libpq-dev
-          - python3-dev
-          - python3-psycopg2
           - "postgresql-client-{{ postgres_version }}"
-        state: present
+        state: latest
         update_cache: true
+        default_release: "{{ ansible_distribution_release }}-pgdg"
 
     - name: set fqdn for use in pg_hba
       ansible.builtin.set_fact:


### PR DESCRIPTION
**Associated Issue(s):** resolves #

### Changes in this PR
_Include all key changes in this pull request_

- Updates PostgreSQL client library installation so libpq5, libpq-dev, and postgresql-client-{{ postgres_version }} are installed from PGDG together.
- Pins Phusion Passenger packages so passenger and libnginx-mod-http-passenger are installed from the Phusion APT repository together.
- Installs Ubuntu nginx-extras separately from Phusion Passenger packages to avoid apt resolver conflicts.

### Notes
_Include any additional notes that will help in the reviewing of this pull request_

- The new VM was first tested on Ubuntu 24.04 Noble, which exposed Python 3.11 package availability and PEP 668 issues.
- After reverting the VM back to Ubuntu 22.04 Jammy, additional apt resolver conflicts were found with PostgreSQL client libraries and Passenger packages.
- This PR keeps Jammy-compatible behavior while making the affected roles safer for Noble where applicable.

### Reviewer Checklist
_Include **discrete** checks that should be done by the reviewer beyond looking through

- [x] Confirm Jammy HTR hosts resolve python_version to 3.11.
- [x] Confirm libpq5, libpq-dev, and postgresql-client-{{ postgres_version }} resolve from PGDG on Jammy.
- [x] Confirm passenger and libnginx-mod-http-passenger resolve from the Phusion APT repository.
- [x] Run playbooks/escriptorium.yml against cdh-test-htr1.lib.princeton.edu and confirm the deployment proceeds past PostgreSQL, Passenger, and Supervisor setup.
