### PR TITLE
Fix/hpc hostname ansible variable

### DIFF
--- a/inventory/group_vars/htr/vars.yml
+++ b/inventory/group_vars/htr/vars.yml
@@ -43,6 +43,7 @@ node_version: "18"
 # not the htr2hpc package. To deploy a specific htr2hpc branch or tag, use:
 #   -e htr2hpc_gitref=adroit
 htr2hpc_gitref: main
+hpc_hostname: "adroit.princeton.edu"
 python_extra_packages:
   - git+https://github.com/Princeton-CDH/htr2hpc.git@{{ htr2hpc_gitref }}#egg=htr2hpc
 

--- a/roles/django/templates/escriptorium_settings.py.j2
+++ b/roles/django/templates/escriptorium_settings.py.j2
@@ -175,7 +175,7 @@ SOLR_CONNECTIONS = {
 # Extra app-specific configuration
 {% block extra_config %}
 # custom config for htr2hpc
-HPC_HOSTNAME = "adroit.princeton.edu"
+HPC_HOSTNAME = "{{ hpc_hostname }}"
 # copied in place by escriptorium_setup role
 HPC_SSH_KEYFILE = "/home/{{ deploy_user }}/.ssh/htr2hpc_id_ed25519"
 


### PR DESCRIPTION
**Associated Issue(s):** resolves Princeton-CDH/htr2hpc#88

### Changes in this PR

- Move hardcoded `HPC_HOSTNAME` value in `escriptorium_settings.py.j2` to an ansible variable `hpc_hostname`

### Notes

### Reviewer Checklist

- [ ] Confirm `HPC_HOSTNAME` is correctly rendered in the deployed settings file