### PR TITLE
Fixes for postgres apt and SSH host key issues

### DIFF
--- a/roles/postgresql/tasks/backup_db.yml
+++ b/roles/postgresql/tasks/backup_db.yml
@@ -20,7 +20,7 @@
       community.postgresql.postgresql_db:
         name: "{{ application_db_name }}"
         login_host: "{{ postgres_host }}"
-        port: "{{ postgres_port }}"
+        login_port: "{{ postgres_port }}"
         login_user: "{{ application_dbuser_name }}"
         login_password: "{{ application_dbuser_password }}"
         encoding: "UTF-8"

--- a/roles/postgresql/tasks/create_db.yml
+++ b/roles/postgresql/tasks/create_db.yml
@@ -7,7 +7,7 @@
   community.postgresql.postgresql_db:
     name: "{{ application_db_name }}"
     login_host: "{{ postgres_host }}"
-    port: "{{ postgres_port }}"
+    login_port: "{{ postgres_port }}"
     login_user: "{{ postgres_admin_user }}"
     login_password: "{{ vault_postgres_admin_password }}"
     encoding: "UTF-8"

--- a/roles/postgresql/tasks/create_user.yml
+++ b/roles/postgresql/tasks/create_user.yml
@@ -7,7 +7,7 @@
   community.postgresql.postgresql_user:
     name: "{{ application_dbuser_name }}"
     login_host: "{{ postgres_host }}"
-    port: "{{ postgres_port }}"
+    login_port: "{{ postgres_port }}"
     login_user: "{{ postgres_admin_user }}"
     login_password: "{{ vault_postgres_admin_password }}"
     password: "{{ application_dbuser_password }}"

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -2,6 +2,22 @@
 - name: Setup Postgres Client and Configuration
   when: postgres_setup_enabled | bool
   block:
+    - name: Remove legacy PGDG apt sources (pre-signed-by cleanup)
+      become: true
+      # Older setups added extra pgdg source files pointing at a different keyring
+      # (postgresql-archive-keyring.gpg): apt_postgresql_org_pub_repos_apt.list is
+      # what the old apt_repository task auto-named, and pgdg.list came from the
+      # PGDG script. Both conflict with the role-managed pgdg.sources below
+      # (Signed-By: .../pgdg/apt.postgresql.org.asc), making apt fail with
+      # "Conflicting values set for option Signed-By". Remove them so only
+      # pgdg.sources remains.
+      ansible.builtin.file:
+        path: "/etc/apt/sources.list.d/{{ item }}"
+        state: absent
+      loop:
+        - apt_postgresql_org_pub_repos_apt.list
+        - pgdg.list
+
     - name: Make sure CA certificates and curl are available
       become: true
       ansible.builtin.apt:

--- a/roles/solr_collection/tasks/main.yml
+++ b/roles/solr_collection/tasks/main.yml
@@ -20,11 +20,13 @@
     - name: Solr_collection - sync project Solr configset files
       become: true
       become_user: "{{ deploy_user }}"
-      # Use -i (itemized changes) to detect if anything actually moved
+      # Use -i (itemized changes) to detect if anything actually moved.
+      # UserKnownHostsFile=/dev/null: don't fail when an app server's host key
+      # changes after a rebuild.
       ansible.builtin.command:
         cmd: >
           /usr/bin/rsync -ai --checksum {{ inventory_hostname }}:{{ install_root }}/current/solr_conf/
-          /solr/cdh_solr/cdh_{{ app_name }}_solr_conf -e "ssh -o StrictHostKeyChecking=no"
+          /solr/cdh_solr/cdh_{{ app_name }}_solr_conf -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
       delegate_to: "{{ solr_server }}"
       register: rsync_out
       changed_when: "rsync_out.stdout != ''"


### PR DESCRIPTION
**Associated Issue(s):** resolves #356

### Changes in this PR

- Resolves #356 by adding a step to remove the old PDPG source files for psql
- Resolves issue with the app server's SSH host key changing from what's stored on the solr server.
   - The existing `-o StrictHostKeyChecking=no` partially fixed this by auto-accepting unknown hosts, but it didn't work for changed ones (e.g. after a VM rebuild). `-o UserKnownHostsFile=/dev/null` just simply ignores known_hosts when performing the rsync step. 
   - If that's not desired, we should probably add troubleshooting steps to the README instead about how to manually update known_hosts to remove and accept a changed key.
- Unrelated, but just while I'm in here, I resolved the deprecation warnings about using `port` instead of `login_port` per [ansible docs](https://docs.ansible.com/projects/ansible/latest/collections/community/postgresql/postgresql_user_module.html#parameter-login_port)

### Notes

- Used Claude to help with diagnosing root causes and making these changes.
- I was able to do a successful geniza staging deploy from this branch: https://ansible-tower.princeton.edu/#/jobs/playbook/52668/output
   - FWIW, I did have to manually go in and install  `passenger` and `libnginx-mod-http-passenger` from apt on both test servers (after [this failure](https://ansible-tower.princeton.edu/#/jobs/playbook/52664/output)), but I'm pretty sure that would be covered by running with the `setup` tasks enabled.
   - I had to skip the `gh_deploy` tag again, as otherwise I'm getting PAT errors. Here's a [failed run with the PAT error](https://ansible-tower.princeton.edu/#/jobs/playbook/52652/output) if someone wants to take a look. It looks like it's not expired, but needs different permissions to create the deploy.