### PR TITLE
[passenger] use nginx-core

### DIFF
--- a/roles/passenger/molecule/default/verify.yml
+++ b/roles/passenger/molecule/default/verify.yml
@@ -13,8 +13,9 @@
       check_mode: true
       register: pkg_status
       loop:
+        - nginx-core
         - libnginx-mod-http-passenger
-        - nginx-extras
+        - passenger
 
     - name: Test for passenger packages
       ansible.builtin.assert:

--- a/roles/passenger/tasks/main.yml
+++ b/roles/passenger/tasks/main.yml
@@ -121,15 +121,6 @@
       when: cache_update.rc != 0
 
     # Nginx and passenger installation.
-    - name: Install Nginx.
-      tags:
-        - setup
-        - never
-      become: true
-      ansible.builtin.apt:
-        name: nginx-extras
-        state: present
-
     - name: Install Passenger and Nginx Passenger module from Phusion.
       tags:
         - setup
@@ -137,8 +128,9 @@
       become: true
       ansible.builtin.apt:
         name:
-          - passenger
+          - nginx-core
           - libnginx-mod-http-passenger
+          - passenger
         state: present
 
     # Nginx and passenger configuration.

--- a/roles/passenger/vars/main.yml
+++ b/roles/passenger/vars/main.yml
@@ -1,8 +1,5 @@
 ---
 __nginx_user: "www-data"
 nginx_passenger_packages:
-  - nginx-extras
+  - nginx-core
   - libnginx-mod-http-passenger
-__nginx_passenger_packages_16_04:
-  - nginx-extras
-  - passenger


### PR DESCRIPTION
closes #393 

Phusion now depends on nginx-common. From `apt-cache show`

```sh
Version: 1:6.1.7-1~jammy1
Depends: ..., nginx-core (= 1.18.0-6ubuntu14.16), passenger (= 1:6.1.7-1~jammy1)
Version: 1:6.1.6-1~jammy1
Depends: ..., nginx-common, passenger (= 1:6.1.6-1~jammy1)
Version: 1:6.1.5-1~jammy1
Depends: ..., nginx-common, passenger (= 1:6.1.5-1~jammy1)`
```

**Associated Issue(s):** resolves #

_If this PR has a deadline, note it here. Remove if there is no deadline._

**Deadline for review**: 

### Changes in this PR

removed all references to nginx-extras


### Notes
_Include any additional notes that will help in the reviewing of this pull request_

from  `apt-cache show` of passenger

```sh
Version: 1:6.1.7-1~jammy1
Depends: ..., nginx-core (= 1.18.0-6ubuntu14.16), passenger (= 1:6.1.7-1~jammy1)
Version: 1:6.1.6-1~jammy1
Depends: ..., nginx-common, passenger (= 1:6.1.6-1~jammy1)
Version: 1:6.1.5-1~jammy1
Depends: ..., nginx-common, passenger (= 1:6.1.5-1~jammy1)
```


