### PR TITLE
Remove legacy eScriptorium hosts from htr_staging inventory

### DIFF
--- a/inventory/all_hosts
+++ b/inventory/all_hosts
@@ -102,8 +102,6 @@ cdh-htr2.lib.princeton.edu
 [htr_staging]
 cdh-test-htr1.lib.princeton.edu
 cdh-test-htr2.lib.princeton.edu
-cdh-test-legacy-htr1.lib.princeton.edu
-cdh-test-legacy-htr2.lib.princeton.edu
 
 [htr:children]
 htr_production


### PR DESCRIPTION
### What's changed
- Removes `cdh-test-legacy-htr1.lib.princeton.edu` and `cdh-test-legacy-htr2.lib.princeton.edu` from `[htr_staging]` in `inventory/all_hosts`

Closes #399