### PR TITLE
Remove recurse from deploy directory task

### DIFF
--- a/roles/build_project_repo/tasks/main.yml
+++ b/roles/build_project_repo/tasks/main.yml
@@ -47,7 +47,6 @@
         owner: "{{ deploy_user }}"
         group: "{{ deploy_user }}"
         mode: '0755'
-        recurse: yes
       tags: [setup]
 
     - name: Mark deploy path as safe for git


### PR DESCRIPTION
Closes #392

- Removes `recurse: yes` from the `Create the specific deploy directory` task in `build_project_repo`
- On eScriptorium VMs with ~177k files, recursively setting ownership exceeds Python's recursion limit and fails the deploy

🤖 Assisted-by: OpenCode:claude-opus-4.7 (for identifying the problem)
