### PR TITLE
Remove recurse from deploy directory task

### DIFF
--- a/inventory/all_hosts
+++ b/inventory/all_hosts
@@ -102,8 +102,6 @@ cdh-htr2.lib.princeton.edu
 [htr_staging]
 cdh-test-htr1.lib.princeton.edu
 cdh-test-htr2.lib.princeton.edu
-cdh-test-legacy-htr1.lib.princeton.edu
-cdh-test-legacy-htr2.lib.princeton.edu
 
 [htr:children]
 htr_production

--- a/roles/build_project_repo/tasks/main.yml
+++ b/roles/build_project_repo/tasks/main.yml
@@ -47,7 +47,6 @@
         owner: "{{ deploy_user }}"
         group: "{{ deploy_user }}"
         mode: '0755'
-        recurse: yes
       tags: [setup]
 
     - name: Mark deploy path as safe for git


### PR DESCRIPTION
Closes #392

### What's changed:
- Removes `recurse: yes` from the `Create the specific deploy directory` task in `build_project_repo`
- On eScriptorium VMs with ~177k files, recursively setting ownership exceeds Python's recursion limit and fails the deploy

### Test plan
- [ ] Run `playbooks/escriptorium.yml` against staging and confirm the deploy directory task completes without recursion error

🤖 Assisted-by: OpenCode:claude-opus-4.7 (for identifying the problem)