### PR TITLE
Fix reinstall-htr2hpc tag: use pip executable instead of virtualenv

### DIFF
--- a/roles/escriptorium_setup/tasks/main.yml
+++ b/roles/escriptorium_setup/tasks/main.yml
@@ -77,13 +77,13 @@
     # remove the current version
     - name: uninstall htr2hpc python package
       ansible.builtin.pip:
-        virtualenv: "{{ django_venv_path }}"
+        executable: "{{ install_root }}/app/env/bin/pip"
         name: htr2hpc
         state: absent
     # reinstall with whatever version is in settings
     - name: install currently configured htr2hpc python package
       ansible.builtin.pip:
-        virtualenv: "{{ django_venv_path }}"
+        executable: "{{ install_root }}/app/env/bin/pip"
         name: "{{ python_extra_packages }}"
         extra_args: "{{ python_extra_packages_pip_extra_args }}"
       notify:

--- a/roles/escriptorium_setup/tasks/main.yml
+++ b/roles/escriptorium_setup/tasks/main.yml
@@ -77,13 +77,15 @@
     # remove the current version
     - name: uninstall htr2hpc python package
       ansible.builtin.pip:
-        executable: "{{ install_root }}/app/env/bin/pip"
+        virtualenv: "{{ django_venv_path }}"
+        virtualenv_command: "python{{ python_version }} -m venv"
         name: htr2hpc
         state: absent
     # reinstall with whatever version is in settings
     - name: install currently configured htr2hpc python package
       ansible.builtin.pip:
-        executable: "{{ install_root }}/app/env/bin/pip"
+        virtualenv: "{{ django_venv_path }}"
+        virtualenv_command: "python{{ python_version }} -m venv"
         name: "{{ python_extra_packages }}"
         extra_args: "{{ python_extra_packages_pip_extra_args }}"
       notify:


### PR DESCRIPTION
### What's changed

- Replace `virtualenv: "{{ django_venv_path }}"` (no `virtualenv_command`) with `virtualenv: "{{ django_venv_path }}"` + `virtualenv_command: "python{{ python_version }} -m venv"` in the `reinstall-htr2hpc` tasks, matching the pattern used in the `python` role

### Notes

The `reinstall-htr2hpc` tasks were using `virtualenv:` without `virtualenv_command`, which causes Ansible's `pip` module to look for a standalone `virtualenv` executable. The HTR servers don't have `virtualenv` installed — they use Python's built-in `venv` module. Other roles (e.g. `python/tasks/install_dependencies.yml`) handle this correctly by also specifying `virtualenv_command: python{{ python_version }} -m venv`. This tag was newly added and had never been run before, so the issue wasn't caught earlier.

The `django_venv_path` variable is fine for HTR — `htr/vars.yml` defines `deploy: "{{ install_root }}"` (single-directory deploy, no hash-based paths), so `django_venv_path` correctly resolves to `/srv/www/escriptorium/app/env`.