### PR TITLE
Update shxo playbooks and vars to use new nodejs role

### DIFF
--- a/inventory/group_vars/shxco/vars.yml
+++ b/inventory/group_vars/shxco/vars.yml
@@ -15,11 +15,11 @@ symlink: mep
 wsgi_path: "{{ django_app }}/wsgi.py"
 # use python 3.12
 python_version: 3.12
-# nodejs version
-node_version: "18"
-
-# skip webpack stats check
-webpack_stats_check_enabled: false
+# nodejs
+nodejs_version: "v22.4.0"
+nodejs_npm_enabled: true
+nodejs_webpack_enabled: true
+nodejs_webpack_stats_check: false # skip webpack stats check
 
 # Override clone root to use deploy user home instead of root
 clone_root: "/home/{{ deploy_user }}/repos"

--- a/playbooks/shxco.yml
+++ b/playbooks/shxco.yml
@@ -6,7 +6,7 @@
   connection: ssh
   remote_user: pulsys
   vars:
-    app_name: cdh_solr   # referenced in deploy user bash profile
+    app_name: cdh_solr # referenced in deploy user bash profile
   roles:
     - deploy_user
 
@@ -17,23 +17,20 @@
   become: true
   roles:
     - role: pulibrary.princeton_ansible.otel_collector
-      when: runtime_env == "staging"
     - role: pulibrary.princeton_ansible.beyla
-      when: runtime_env == "staging"
     - create_deployment
     - deploy_user
     - build_dependencies
     - build_project_repo
     - postgresql
     - passenger
-    - build_npm
-    - run_webpack   # dependency for collectstatic
+    - nodejs # dependency for django collectstatic
     - configure_logging # logging directory must exist before running django commands
     - django
     - solr_collection
     - finalize_deploy
-    - configure_crontab  # used in production but not always in staging
+    - configure_crontab # used in production but not always in staging
     - close_deployment
   tasks:
-    - ansible.builtin.include_role:   # timezone needed for twitter bot cron/at jobs
+    - ansible.builtin.include_role: # timezone needed for twitter bot cron/at jobs
         name: pulibrary.princeton_ansible.timezone


### PR DESCRIPTION
**Associated Issue(s):** ~

### Changes in this PR

- Update shxo playbook and group vars to use the new nodejs role

### Notes

- This branch is chained from #12 as a way of testing the new functionality and making sure I understand it.
- I successfully deployed shxco to staging - I made sure it was a version not already present to force the node role to run through the steps in a fresh deploy directory.